### PR TITLE
Issue #15 Provide templates for contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,63 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!--
+Provide a general summary of this issue in English, in the Title above.
+上のタイトル欄に、このIssueの概要を *英語で* 記入してください。
+-->
+
+## Description
+<!--
+Describe a more detailed introduction to the bug itself, and why you consider it to be a problem.
+-->
+
+## Steps to reproduce
+<!--
+Please provide detailed steps for reproducing the issue.
+Include code to reproduce, if relevant.
+
+Ex.
+- Testcase
+1. Go to '...'.
+1. Click on '....'.
+    1. Scroll down to '....'.
+    1. Input '....'.
+1. Click on '....'.
+1. See result.
+-->
+
+## Expected Results
+<!--
+Explain in a clear and concise description what you expected to happen.
+-->
+
+## Actual Results
+<!---
+Explain what happens instead of the expected results.
+-->
+
+## Enviroment
+<!--
+Include as many relevant details about the environment you experienced the bug in.
+If this part is unnecessary, please remove it.
+
+Ex.
+- Target version:
+- Operating system and version (desktop or mobile):
+- Web browser name and version:
+-->
+
+## Debug Log
+<!--
+Include any relevant log snippets or files here.
+If this item is unnecessary, please remove it.
+-->
+
+## References
+<!--
+It is described when there is a reference article.
+If this item is unnecessary, please remove it.
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+Provide a general summary of this issue in English, in the Title above.
+上のタイトル欄に、このIssueの概要を *英語で* 記入してください。
+-->
+
+## Description
+<!--
+Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is.
+
+Ex.
+I'm always frustrated when [...]
+-->
+
+## Solution
+<!--
+Describe the solution you'd like.
+A clear and concise description of what you want to happen.
+-->
+
+## Alternatives
+<!--
+Describe alternatives you've considered.
+A clear and concise description of any alternative solutions or features you've considered.
+-->
+
+## Additional context
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+<!--
+Provide an outline of this pull request in English, in the Title above.
+上のタイトル欄に、プルリクエストの概要を *英語で* 記入してください。
+
+Please be sure to write the title in the following format.
+タイトルは以下の形式で記述してください。
+
+Issue #<Issue id> <Outline of this pull request>
+-->
+
+## Analysis
+<!--
+Provide the root cause of the pull request.
+問題の根本原因を記載してください。
+-->
+
+## Solution
+<!--
+Provide the solution.
+解決策を記載してください。
+-->
+
+## Install/Update
+<!--
+Provide how to apply the modification.
+When it can not be applied by simple module replacement such as modification of service schema.
+
+この変更の適用方法を記載してください。
+サービススキーマの修正など、単純なモジュール差し替えでは適用できない場合が該当します。
+-->
+
+## Compatibility
+<!--
+Describe the effect on performance.
+Such as when there is concern about performance degradation.
+
+外部仕様に変更がある場合に記載してください。
+HTTP ステータスコードが変更される場合などが該当します。
+-->
+
+## Performance
+<!--
+Describe the effect on performance.
+性能に及ぼす影響を記載してください。
+-->
+
+## I18N
+<!--
+Provide the impact on internationalization.
+If you need attention to other languages, such as when changing the wording of the error message.
+
+国際化への影響を記載してください。
+エラーメッセージの文言を変更した場合など、他言語に注意が必要な場合が該当します。
+-->
+
+## Testing
+<!--
+Provide the necessary test procedures to confirm the modification.
+修正を確認するために必要なテスト手順を記載してください。
+-->
+
+## Regression testing
+<!--
+Provide the result of the regression test.
+リグレッションテストの結果を記載してください。
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,8 @@ When it can not be applied by simple module replacement such as modification of 
 
 ## Compatibility
 <!--
-Describe the effect on performance.
-Such as when there is concern about performance degradation.
+Describe changes in external specifications.
+For example, if the HTTP status code has been changed.
 
 外部仕様に変更がある場合に記載してください。
 HTTP ステータスコードが変更される場合などが該当します。


### PR DESCRIPTION
Issue #15 Provide templates for contributions


## Analysis
関係者が価値ある作業に注力できるよう、定型的な作業はできるだけ単純化したいです。
IssueやPull-Requestの見出しや体裁を揃えることに割く時間を減らし、コードをより良くする時間に振り替えられたら幸いです。
副次的な効果として、IssueやPull-Requestの質が揃うことで可読性が上がること、GitHubコミュニティプロファイルの評価が上がることを期待しています。

## Solution
### GitHubから提供されるテンプレート機能を利用する
- 「.github」ディレクトリ配下に、規定の名前のテキストファイルを格納する
### 重要と考えられる3種を作成した
1. Bug-Issue (bug-report.md)
1. Feature-Issue (feature-request.md)
1. Pull-Request (PULL_REQUEST_TEMPLATE.md)
### ガイドライン的な文章はコメントタグとして埋め込んだ
下記理由から、この方式が利便性が高いと考えました。
- コメントタグは編集中のみ表示され、確定すると非表示となる
- 文字列として埋め込む方式と比べ、「まず削除」の手間が無くなる
- うっかり必要な箇所まで削除しすぎるリスクも減少する
### 部分的に、英語文と日本語文を併記した
コミュニティの性質上、日本語圏の方が多く参加されると想定され、「予備知識が無くても方針を汲み取りやすいこと」を重視しました。
- 英語文のみだと、英語が不得手な方は見落とす可能性が高いと考えた
- 「タイトル欄は英語で記入頂きたい」旨だけは、日本語も併記した
- その他は、日本語OKの項目は日本語も併記、英語のみの項目は英語のみとした

## Testing
1. テキスト内容をクリップボードへコピーする
1. 新規Issueや新規Pull-Requestを起票し、テキスト入力欄へペーストする

## Regression testing
個人アカウントのリポジトリにて動作確認しました。
