### PR TITLE
Issue #6 Search Timeout for LDAP filter condition should be in seconds

### DIFF
--- a/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/datastore/AddAMSDKIdRepoPlugin.java
+++ b/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/datastore/AddAMSDKIdRepoPlugin.java
@@ -395,7 +395,7 @@ public class AddAMSDKIdRepoPlugin extends AuthenticatedCommand {
     private ConnectionFactory getLDAPConnection(DSEntry ds) throws Exception {
         BindRequest bindRequest = LDAPRequests.newSimpleBindRequest(bindDN, bindPwd.toCharArray());
         Options options = Options.defaultOptions()
-                .set(CONNECT_TIMEOUT, new Duration((long) 300, TimeUnit.MILLISECONDS))
+                .set(CONNECT_TIMEOUT, new Duration((long) 300, TimeUnit.SECONDS))
                 .set(AUTHN_BIND_REQUEST, bindRequest);
 
         if (ds.ssl) {

--- a/openam-core/src/main/java/com/sun/identity/idm/common/IdRepoUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/idm/common/IdRepoUtils.java
@@ -25,6 +25,7 @@
  * $Id: IdRepoUtils.java,v 1.3 2010/01/06 22:31:55 veiming Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2018 Open Source Solution Technology Corporation
  */
 
 package com.sun.identity.idm.common;
@@ -330,7 +331,7 @@ public class IdRepoUtils {
     private static ConnectionFactory getLDAPConnection(Map attrValues)
         throws Exception {
         Options options = Options.defaultOptions()
-                .set(CONNECT_TIMEOUT, new Duration((long) 300, TimeUnit.MILLISECONDS));
+                .set(CONNECT_TIMEOUT, new Duration((long) 300, TimeUnit.SECONDS));
         String connectionMode = CollectionHelper.getMapAttr(attrValues, LDAP_CONNECTION_MODE);
         if (LDAP_CONNECTION_MODE_LDAPS.equalsIgnoreCase(connectionMode) ||
                 LDAP_CONNECTION_MODE_STARTTLS.equalsIgnoreCase(connectionMode)){

--- a/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
@@ -570,7 +570,7 @@ public class LDAPFilterCondition implements Condition {
 
         // initialize the connection pool for the ldap server
         Options options = Options.defaultOptions()
-                .set(CONNECT_TIMEOUT, new Duration((long) timeLimit, TimeUnit.MILLISECONDS));
+                .set(CONNECT_TIMEOUT, new Duration((long) timeLimit, TimeUnit.SECONDS));
 
         LDAPConnectionPools.initConnectionPool(ldapServer, authid, authpw, sslEnabled, minPoolSize, maxPoolSize,
                 options);

--- a/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPRoles.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPRoles.java
@@ -244,7 +244,7 @@ public class LDAPRoles implements Subject {
 
         // initialize the connection pool for the ldap server
         Options options = Options.defaultOptions()
-                .set(REQUEST_TIMEOUT, new Duration((long)timeLimit, TimeUnit.MILLISECONDS));
+                .set(REQUEST_TIMEOUT, new Duration((long)timeLimit, TimeUnit.SECONDS));
 
         LDAPConnectionPools.initConnectionPool(ldapServer, authid, authpw, sslEnabled, minPoolSize, maxPoolSize,
                 options);

--- a/openam-core/src/main/java/org/forgerock/openam/ldap/LDAPAuthUtils.java
+++ b/openam-core/src/main/java/org/forgerock/openam/ldap/LDAPAuthUtils.java
@@ -274,7 +274,7 @@ public class LDAPAuthUtils {
                 synchronized (connectionPools) {
                     connPool = connectionPools.get(configName);
                     Options options = Options.defaultOptions()
-                            .set(REQUEST_TIMEOUT, new Duration((long) operationsTimeout, TimeUnit.MILLISECONDS));
+                            .set(REQUEST_TIMEOUT, new Duration((long) operationsTimeout, TimeUnit.SECONDS));
 
                     if (connPool == null) {
                         if (debug.messageEnabled()) {


### PR DESCRIPTION
## Analysis

LDAP SDK を OpenDJ SDK に変更した際のミスと考えられます。
変更前は LDAP プロトコルの timelimit（秒）として利用されていた設定を OpenDJ SDK に移行する際にミリ秒の設定として扱うようになったことが原因です。

## Solution

OPENAM-8459 の修正を cherry-pick し、タイムアウトの単位をミリ秒から秒に変更します。

## Install/Update

N/A

## Compatibility

タイムアウトの単位が秒として正しく扱われるようになりました。

## Performance

N/A

## I18N

N/A

## Testing

* LDAPFilterCondition.java
  * LDAP フィルター条件（Policy Configuration Service）の検索タイムアウトを 1 にした場合にポリシー保護下にアクセスできること（修正前はアクセス拒否）
* LDAPAuthUtils.java
  * LDAP 認証モジュールの LDAP 操作タイムアウトの設定を 1 にした場合に認証できること（修正前は認証失敗）
* AddAMSDKIdRepoPlugin.java
  * コードレビューのみ
* LDAPRoles.java
  * コードレビューのみ

## Regression testing

N/A
