### PR TITLE
Issue #7 ForceAuth cause JSON callbacks error

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/core/LoginAuthenticator.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/core/LoginAuthenticator.java
@@ -16,6 +16,7 @@
 
 /*
  * Portions Copyrighted 2014 Nomura Research Institute, Ltd
+ * Portions Copyrighted 2018 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.core.rest.authn.core;
 
@@ -187,11 +188,12 @@ public class LoginAuthenticator {
         HttpServletResponse response = loginConfiguration.getHttpResponse();
         SessionID sessionID = new SessionID(loginConfiguration.getSessionId());
         boolean isSessionUpgrade = false;
-        if (loginConfiguration.isSessionUpgradeRequest() && sessionID.isNull() || loginConfiguration.isForceAuth()) {
+        if (loginConfiguration.isSessionUpgradeRequest() && sessionID.isNull()) {
             sessionID = new SessionID(loginConfiguration.getSSOTokenId());
             SSOToken ssoToken = coreServicesWrapper.getExistingValidSSOToken(sessionID);
             isSessionUpgrade = checkSessionUpgrade(ssoToken, loginConfiguration.getIndexType(),
-                    loginConfiguration.getIndexValue()) || loginConfiguration.isForceAuth();
+                    loginConfiguration.getIndexValue())
+                    || (loginConfiguration.isForceAuth() && (ssoToken != null));
         }
         boolean isBackPost = false;
         return coreServicesWrapper.getAuthContext(request, response, sessionID, isSessionUpgrade, isBackPost);

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/AuthUtils.java
@@ -277,12 +277,12 @@ public class AuthUtils extends AuthClientUtils {
                     if (isSessionUpgrade) {
                         loginState.setOldSession(oldSession);
                         loginState.setSessionUpgrade(isSessionUpgrade);
+                        loginState.setForceAuth(Boolean.parseBoolean(request.getParameter(FORCE_AUTH)));
                     } else if (isBackPost) {
                         loginState.setOldSession(oldSession);
                     }
                     authContext =
                     loginState.createAuthContext(request,response,sid,dataHash);
-                    loginState.setForceAuth(Boolean.parseBoolean(request.getParameter(FORCE_AUTH)));
                     authContext.setLoginState(loginState);
                     String queryOrg =
                     getQueryOrgName(request,getOrgParam(dataHash));


### PR DESCRIPTION
## Analysis

OpenAM13 の時点では XUI は初回の認証 REST API のみにクエリーパラメーターを付与していた。
そして、OPENAM-8879 の修正(21c70bb)によって XUI は認証 REST API をコールする際に毎回クエリーパラメーター（ForceAuth を含む）を付与するようになった。
しかし、この変更に対してサーバーサイドの処理には変更を行わなかったため、認証ステージの判定に異常をきたしてしまったと考えられる。

LoginAuthenticator.startLoginProcess() は正常時は初回の REST API でしか実行されないが、ForceAuth が付与されていると毎回実行されてしまう。
その結果、認証モジュールのコールバックの先頭の処置が実行されるが、たとえば HOTP 認証では先頭のコールバックが空のため（HOTP.xml 参照）POST された情報と一致せず、JSON コールバックエラーが発生する

## Solution

内部処理ではセッションアップグレードと判定すると新規リクエスト扱いとなり、LoginAuthenticator.startLoginProcess() を実行してしまう。その
ため、セッションアップグレードの判定を行っている LoginAuthenticator.getAuthContext() を修正する。

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
* 「ForceAuth」&「DataStore & HOTP の認証連鎖」の組み合わせで問題が発生しないこと

## Regression testing
* セッションがある状態から ForceAuth で再度認証がもとめられること
* 「ForceAuth」&「XUI を無効」の組み合わせで問題が発生しないこと
