### PR TITLE
Issue #21 Upgrade dependencies.

### DIFF
--- a/legal-oem/THIRDPARTYREADME.txt
+++ b/legal-oem/THIRDPARTYREADME.txt
@@ -215,16 +215,16 @@ Copyright: Copyright 2005-2015 The Apache Software Foundation
 Version: httpcore-nio-4.4.1.jar
 Copyright: 2005-2015 The Apache Software Foundation
 
-Version: jackson-annotations-2.4.2.jar
+Version: jackson-annotations-2.8.11.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-core-2.4.2.jar
+Version: jackson-core-2.8.11.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-core-asl-1.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-databind-2.4.2.jar
+Version: jackson-databind-2.8.11.2.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-dataformat-csv-2.6.3.jar
@@ -233,7 +233,7 @@ Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless othe
 Version: jackson-dataformat-smile-2.4.4.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-dataformat-xml-2.4.2.jar
+Version: jackson-dataformat-xml-2.8.11.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: jackson-dataformat-yaml-2.4.4.jar

--- a/legal-oem/THIRDPARTYREADME.txt
+++ b/legal-oem/THIRDPARTYREADME.txt
@@ -215,16 +215,16 @@ Copyright: Copyright 2005-2015 The Apache Software Foundation
 Version: httpcore-nio-4.4.1.jar
 Copyright: 2005-2015 The Apache Software Foundation
 
-Version: jackson-annotations-2.8.11.jar
+Version: jackson-annotations-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-core-2.8.11.jar
+Version: jackson-core-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-core-asl-1.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-databind-2.8.11.2.jar
+Version: jackson-databind-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-dataformat-csv-2.6.3.jar
@@ -233,7 +233,7 @@ Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless othe
 Version: jackson-dataformat-smile-2.4.4.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-dataformat-xml-2.8.11.jar
+Version: jackson-dataformat-xml-2.9.7.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: jackson-dataformat-yaml-2.4.4.jar

--- a/legal/THIRDPARTYREADME.txt
+++ b/legal/THIRDPARTYREADME.txt
@@ -227,16 +227,16 @@ Copyright: Copyright 2005-2015 The Apache Software Foundation
 Version: httpcore-nio-4.4.1.jar
 Copyright: 2005-2015 The Apache Software Foundation
 
-Version: jackson-annotations-2.8.11.jar
+Version: jackson-annotations-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-core-2.8.11.jar
+Version: jackson-core-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-core-asl-1.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-databind-2.8.11.2.jar
+Version: jackson-databind-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-dataformat-csv-2.6.3.jar
@@ -245,7 +245,7 @@ Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless othe
 Version: jackson-dataformat-smile-2.4.4.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-dataformat-xml-2.8.11.jar
+Version: jackson-dataformat-xml-2.9.7.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: jackson-dataformat-yaml-2.4.4.jar

--- a/legal/THIRDPARTYREADME.txt
+++ b/legal/THIRDPARTYREADME.txt
@@ -227,16 +227,16 @@ Copyright: Copyright 2005-2015 The Apache Software Foundation
 Version: httpcore-nio-4.4.1.jar
 Copyright: 2005-2015 The Apache Software Foundation
 
-Version: jackson-annotations-2.4.2.jar
+Version: jackson-annotations-2.8.11.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-core-2.4.2.jar
+Version: jackson-core-2.8.11.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-core-asl-1.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-databind-2.4.2.jar
+Version: jackson-databind-2.8.11.2.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: jackson-dataformat-csv-2.6.3.jar
@@ -245,7 +245,7 @@ Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless othe
 Version: jackson-dataformat-smile-2.4.4.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-dataformat-xml-2.4.2.jar
+Version: jackson-dataformat-xml-2.8.11.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: jackson-dataformat-yaml-2.4.4.jar

--- a/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/rest/JsonPolicyParser.java
+++ b/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/rest/JsonPolicyParser.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2014-2015 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 
 package org.forgerock.openam.entitlement.rest;
@@ -149,7 +149,7 @@ public final class JsonPolicyParser implements PolicyParser {
             return privilege;
         } catch (UnrecognizedPropertyException ex) {
             throw new EntitlementException(EntitlementException.INVALID_VALUE,
-                    new Object[] { ex.getUnrecognizedPropertyName() });
+                    new Object[] { ex.getPropertyName() });
         } catch (JsonMappingException ex) {
             throw new EntitlementException(EntitlementException.INVALID_JSON, ex, ex.getMessage());
         } catch (IOException e) {

--- a/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/rest/model/json/EntitlementsRegistryTypeIdResolver.java
+++ b/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/rest/model/json/EntitlementsRegistryTypeIdResolver.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2014-2015 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 
 package org.forgerock.openam.entitlement.rest.model.json;
@@ -19,6 +19,7 @@ package org.forgerock.openam.entitlement.rest.model.json;
 import org.forgerock.openam.entitlement.EntitlementRegistry;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -67,7 +68,7 @@ public abstract class EntitlementsRegistryTypeIdResolver<T> extends TypeIdResolv
     }
 
     @Override
-    public JavaType typeFromId(String id) {
+    public JavaType typeFromId(DatabindContext context, String id) {
         Class<? extends T> subType = getType(registry, id);
         if (subType == null) {
             throw new IllegalArgumentException("No such type: '" + id + "'");

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,8 @@
         <guice.version>3.0</guice.version>
         <restlet.version>2.3.4</restlet.version>
         <powermock.version>1.5</powermock.version>
-        <jackson.version>2.4.2</jackson.version>
+        <jackson.version>2.8.11</jackson.version>
+        <jackson-databind.version>2.8.11.2</jackson-databind.version>
         <slf4j.version>1.7.5</slf4j.version>
         <santuario.xmlsec.version>1.5.6</santuario.xmlsec.version>
         <click.version>2.3.0</click.version>
@@ -177,7 +178,7 @@
         <json.version>20090211</json.version>
         <hikaricp.version>2.4.1</hikaricp.version>
         <h2database.version>1.4.188</h2database.version>
-        <activemq.version>5.13.3</activemq.version>
+        <activemq.version>5.15.6</activemq.version>
         <javax.inject.version>1_2</javax.inject.version>
         <fastinfoset.version>1.2.13</fastinfoset.version>
         <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
@@ -1622,7 +1623,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,7 @@
         <guice.version>3.0</guice.version>
         <restlet.version>2.3.4</restlet.version>
         <powermock.version>1.5</powermock.version>
-        <jackson.version>2.8.11</jackson.version>
-        <jackson-databind.version>2.8.11.2</jackson-databind.version>
+        <jackson.version>2.9.7</jackson.version>
         <slf4j.version>1.7.5</slf4j.version>
         <santuario.xmlsec.version>1.5.6</santuario.xmlsec.version>
         <click.version>2.3.0</click.version>
@@ -178,7 +177,7 @@
         <json.version>20090211</json.version>
         <hikaricp.version>2.4.1</hikaricp.version>
         <h2database.version>1.4.188</h2database.version>
-        <activemq.version>5.15.6</activemq.version>
+        <activemq.version>5.13.3</activemq.version>
         <javax.inject.version>1_2</javax.inject.version>
         <fastinfoset.version>1.2.13</fastinfoset.version>
         <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
@@ -1623,7 +1622,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
## Analysis

The version of the Jackson library that OpenAM specifies (2.4.2) is old and may contain vulnerabilities.
Therefore, we should update the value of 'jackson.version' and the source code interface.


## Solution

Upgrade these libraries that depend on build.

- jackson-annotations, jackson-core, jackson-dataformat-xml -> 2.8.11
- jackson-databind -> 2.8.11.2
- activemq (is used only for unit tests) -> 5.15.6
- Fix method signature mismatch.
- Fix README.



## Testing

- Build -> Successful.
- Unit testing -> Successful.
- Smoke testing -> Successful.
