### PR TITLE
Issue #26 Suppress monitoring error in CoreSystem during OpenAM startup

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/common/ConfigMonitoring.java
+++ b/openam-core/src/main/java/com/sun/identity/common/ConfigMonitoring.java
@@ -138,8 +138,12 @@ public class ConfigMonitoring {
          * will result in monitoring getting disabled.
          */
         int i = getMonServiceAttrs();
-        if (i < Agent.MON_CONFIG_DISABLED) {
-            debug.error("{}getMonServiceAttrs returns {}, monitoring disabled", classMethod, i);
+        if (i <= Agent.MON_CONFIG_DISABLED) {
+            if (i == Agent.MON_CONFIG_DISABLED) {
+                debug.message("{}getMonServiceAttrs returns {}, monitoring disabled", classMethod, i);
+            } else {
+                debug.error("{}getMonServiceAttrs returns {}, monitoring disabled", classMethod, i);
+            }
             Agent.setMonitoringDisabled();
             return;
         }

--- a/openam-core/src/main/java/com/sun/identity/common/ConfigMonitoring.java
+++ b/openam-core/src/main/java/com/sun/identity/common/ConfigMonitoring.java
@@ -26,7 +26,6 @@
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
  */
-
 package com.sun.identity.common;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -139,9 +138,8 @@ public class ConfigMonitoring {
          * will result in monitoring getting disabled.
          */
         int i = getMonServiceAttrs();
-        if (i != 0) {
-            debug.error(classMethod + "getMonServiceAttrs returns " + i +
-                ", monitoring disabled");
+        if (i < Agent.MON_CONFIG_DISABLED) {
+            debug.error("{}getMonServiceAttrs returns {}, monitoring disabled", classMethod, i);
             Agent.setMonitoringDisabled();
             return;
         }


### PR DESCRIPTION
## Analysis

In the ConfigMonitoring class, an error occurs if the monitoring configuration is not enable.

```
openam-core/src/main/java/com/sun/identity/common/ConfigMonitoring.java
 141         int i = getMonServiceAttrs();
 142         if (i != 0) {
 143             debug.error(classMethod + "getMonServiceAttrs returns " + i +
 144                 ", monitoring disabled");
 145             Agent.setMonitoringDisabled();
 146             return;
 147         }
```

The `i` takes the following value.

* (OK) -> 0
* MON_CONFIG_DISABLED -> -1
* MON_MBEANSRVR_PROBLEM -> -2
* MON_RMICONNECTOR_PROBLEM -> -3
* MON_CREATEMIB_PROBLEM -> -4
* MON_READATTRS_PROBLEM -> -5

We should exclude MON_CONFIG_DISABLED from error.

## Solution

Cherry picked OPENAM-3415(9ae9637) and OPENAM-9814(b16f43e)

## Testing

* No error output in CoreSystem debug log during OpenAM startup
* ssoconfigurator works