### PR TITLE
Issue #30 Auth Error messages ignore Accept-Language

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/authentication/client/AuthClientUtils.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/client/AuthClientUtils.java
@@ -25,6 +25,7 @@
  * $Id: AuthClientUtils.java,v 1.40 2010/01/22 03:31:01 222713 Exp $
  *
  * Portions Copyrighted 2010-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.authentication.client;
 
@@ -1855,9 +1856,20 @@ public class AuthClientUtils {
             bundle = Locale.getInstallResourceBundle(BUNDLE_NAME);
         }
 
+        return getErrorVal(errorCode, type, bundle);
+    }
+    
+    public static String getErrorVal(String errorCode,String type,
+            ResourceBundle bundle) {
+
+        ResourceBundle errMsgBundle = bundle;
+        if (errMsgBundle == null) {
+            errMsgBundle = Locale.getInstallResourceBundle(BUNDLE_NAME);
+        }
+
         String errorMsg=null;
         String templateName=null;
-        String resProperty = bundle.getString(errorCode);
+        String resProperty = errMsgBundle.getString(errorCode);
         if (utilDebug.messageEnabled()) {
             utilDebug.message("errorCod='{}', resProperty='{}'", errorCode, resProperty);
         }

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/AMLoginContext.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/AMLoginContext.java
@@ -26,6 +26,7 @@
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
  * Portions Copyrighted 2014 Nomura Research Institute, Ltd
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.authentication.service;
 
@@ -1517,7 +1518,7 @@ public class AMLoginContext {
             if (debug.messageEnabled()) {
                 debug.message("resProperty is.. :" + resProperty);
             }
-            String errorMsg = AuthUtils.getErrorVal(errorCode, AuthUtils.ERROR_MESSAGE);
+            String errorMsg = AuthUtils.getErrorVal(errorCode, AuthUtils.ERROR_MESSAGE, bundle);
             String templateName = AuthUtils.getErrorVal(errorCode, AuthUtils.ERROR_TEMPLATE);
 
             if (debug.messageEnabled()) {


### PR DESCRIPTION
## Analysis

Authentication error messages of REST API are obtained from `LoginState`. LoginState stores the message generated by `AuthClientUtils.getErrorVal()`, but this method only refers to the platform locale.

```
openam-core/src/main/java/com/sun/identity/authentication/client/AuthClientUtils.java
 1852     public static String getErrorVal(String errorCode,String type) {
 1853 
 1854         if (Locale.getDefaultLocale() != bundle.getLocale()) {
 1855             bundle = Locale.getInstallResourceBundle(BUNDLE_NAME);
 1856         }
```

## Solution

Create error message from request locale.

## Install/Update

N/A

## Compatibility

N/A

## Performance

N/A

## I18N

Error messages now refer to Accept-Language.

## Testing

* Authentication Error(DataStore Auth)
* Authentication Session Timedout(This needs translation.json)
* Max Session Count
* Profile Error
* User Incative
* Organization Incative
* Account Lockedout
* Account expired
* Service does not exist
* Auth Level does not exist

## Regression testing

N/A