### PR TITLE
Issue #29 JavaMail debug logs are output to stdout

### DIFF
--- a/openam-core/src/main/java/com/iplanet/am/util/AMSendMail.java
+++ b/openam-core/src/main/java/com/iplanet/am/util/AMSendMail.java
@@ -25,6 +25,7 @@
  * $Id: AMSendMail.java,v 1.6 2009/12/22 19:57:19 qcheng Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation.
  */
 package com.iplanet.am.util;
 

--- a/openam-core/src/main/java/com/iplanet/am/util/AMSendMail.java
+++ b/openam-core/src/main/java/com/iplanet/am/util/AMSendMail.java
@@ -190,7 +190,7 @@ public class AMSendMail {
         Properties moduleProps = new Properties();
 
         moduleProps.put("mail.smtp.host", host);
-        moduleProps.put("mail.debug", "true");
+        moduleProps.put("mail.debug", "false");
         moduleProps.put("mail.smtp.port", port);
         moduleProps.put("mail.smtp.socketFactory.port", port);
         if (ssl) {


### PR DESCRIPTION
## Analysis
The JavaMail debug option is set to "ture". 

```
    193         moduleProps.put("mail.debug", "true");
```

## Solution
The JavaMail debug option is set to "false". 


## Testing
JavaMail log is not output to catalina.out when sending mail using HOTP authentication module.


