### PR TITLE
Issue #12 User remains on 'Loading' page if using 'OAuth2.0/OIDC' aut…

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 define([
     "jquery",
@@ -157,6 +158,13 @@ define([
                 // we timed out, so let's try again with a fresh session
                 oldReqs = requirementList[0];
                 obj.resetProcess();
+
+                // Suppress retry when using Redirect Callback
+                if (AuthenticationToken.get()) {
+                    EventManager.sendEvent(Constants.EVENT_DISPLAY_MESSAGE_REQUEST, "loginTimeout");
+                    return $.Deferred().reject(currentStage, reasonThatWillNotBeDisplayed).promise();
+                }
+
                 return obj.begin().then((requirements) => {
                     obj.handleRequirements(requirements);
                     if (requirements.hasOwnProperty("authId")) {


### PR DESCRIPTION
## Analysis

XUI has a mechanism to automatically redo the authentication request when the authId has expired. However, when using the OAuth authentication module, this mechanism causes an unexpected exception. Because the automatically executed request ignores the authentication stage and has an authorization code.

If the authentication module such as OAuth authentication module uses a redirect callback, we should suppress retry when authId token expires. So, user can restart authentication process from the beginning.

Also, by suppressing retries, error messages will be easier to read.

## Solution

Suppress authentication retries, if the authId token has expired and is given as a cookie.

## Testing

See Issue #12 "Steps to reproduce"