### PR TITLE
Issue #50 Deleting an instance of the authentication module registered by default also deletes the authentication modules of the same type

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2015-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions Copyrighted 2017 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.core.rest.sms;

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2015-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyrighted 2017 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.core.rest.sms;

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsCollectionProvider.java
@@ -159,10 +159,16 @@ public class SmsCollectionProvider extends SmsResourceProvider {
             ServiceConfigManager scm = getServiceConfigManager(context);
             ServiceConfig config = parentSubConfigFor(context, scm);
             checkedInstanceSubConfig(context, resourceId, config);
-            if (isDefaultCreatedAuthModule(context, resourceId)) {
-                scm.removeOrganizationConfiguration(realmFor(context), null);
-            } else {
+
+            Set<String> subConfigNames = config.getSubConfigNames();
+            if (subConfigNames.contains(resourceId)) {
                 config.removeSubConfig(resourceId);
+            } else if (isDefaultCreatedAuthModule(context, resourceId)) {
+                if (subConfigNames.size() == 0) {
+                    scm.removeOrganizationConfiguration(realmFor(context), null);
+                } else {
+                    config.removeAttributes(config.getAttributesWithoutDefaults().keySet());
+                }
             }
 
             return awaitDeletion(context, resourceId)


### PR DESCRIPTION


<!--
Provide an outline of this pull request in English, in the Title above.
上のタイトル欄に、プルリクエストの概要を *英語で* 記入してください。

Please be sure to write the title in the following format.
タイトルは以下の形式で記述してください。

Issue #<Issue id> <Outline of this pull request>
-->

<!--
## Analysis
Provide the root cause of the pull request.
問題の根本原因を記載してください。
-->

## Solution
<!--
Provide the solution.
解決策を記載してください。
-->

previous code remove all of config tree when remove default module or same name of default module.

new delete process first check if target module is  subConfig.
if module is not subConfig, check target module is default module.
finally, check if default module have subConfig. not have subConfig remove default module config tree.
if module have subConfig remove default module setting only.

if target module is not default but same name of default module, remove that when first check timing.

<!--
## Install/Update
Provide how to apply the modification.
When it can not be applied by simple module replacement such as modification of service schema.

この変更の適用方法を記載してください。
サービススキーマの修正など、単純なモジュール差し替えでは適用できない場合が該当します。
-->

<!--
## Compatibility
Describe changes in external specifications.
For example, if the HTTP status code has been changed.

外部仕様に変更がある場合に記載してください。
HTTP ステータスコードが変更される場合などが該当します。
-->

<!--
## Performance
Describe the effect on performance.
性能に及ぼす影響を記載してください。
-->

<!--
## I18N
Provide the impact on internationalization.
If you need attention to other languages, such as when changing the wording of the error message.

国際化への影響を記載してください。
エラーメッセージの文言を変更した場合など、他言語に注意が必要な場合が該当します。
-->

## Testing
<!--
Provide the necessary test procedures to confirm the modification.
修正を確認するために必要なテスト手順を記載してください。
-->

a.
1. Create a new module instance with a default module
2. Delete default module instance

b.
1. Delete default module instance
2. Create a new module instance same name of default module
3. Delete 2. instance

<!--
## Regression testing
Provide the result of the regression test.
リグレッションテストの結果を記載してください。
-->

### previous pullrequest comment reply

> We already have a patch for this problem, right?

yes. but that patch is not good.(patch include OPENAM-9156 fix,I want to fix that another pull request)

> I can not understand why you ignore the patch (including the background of the creation) and try to create it.
> By the way, according to CERT Secure Coding Standards, do not catch NPE.

1. isDefaultCreatedAuthModule is not need change
Previous patch is changed isDefaultCreatedAuthModule method  to check same name of default module.
But that change is not need. (often destructive change for another methods)
That fix need OPENAM-9156, not this issue.

2. mysterious null pointer check
previous patch do null-check to config.getSubConfigNames.
but config.getSubConfigNames is this code

* ServiceConfig.java

```
public Set<String> getSubConfigNames() throws SMSException {
validateServiceConfigImpl();
try {
return sc.getSubConfigNames(token);
} catch (SSOException s) {
SMSEntry.debug.error("ServiceConfig: Unable to "
+ "get subConfig Names", s);
}
return (Collections.EMPTY_SET);
}
```

its always return some of set object. not need null check.
