### PR TITLE
Issue #42  acr_values not working if the user is login in more than one chain

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/ResourceOwnerSessionValidator.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/ResourceOwnerSessionValidator.java
@@ -46,12 +46,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.text.ParseException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.StringTokenizer;
 
 import com.iplanet.sso.SSOException;
 import com.iplanet.sso.SSOToken;


### PR DESCRIPTION
##  Analysis
When the user login in more than one chain, in the user session, a value such as `/:chanB|chanA` is stored as the authentication chain information.
OpenAM does not handle such values correctly in ResourceOwnerSessionValidator, so it fails to compare with acr_values.
As a result, OpenAM(OP) returns `acr = 0`.

## Solution
Parse authentication chain information in user session correctly.

## Testing

See Issue #42 "Steps to reproduce"

