### PR TITLE
Issue #54 Can not edit policy using IE11

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/AuthenticationService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/AuthenticationService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 /**
@@ -173,8 +174,11 @@ define([
             },
             exists (realm, name) {
                 var promise = $.Deferred(),
+                    queryFilter = encodeURIComponent(`_id eq "${name}"`),
                     request = obj.serviceCall({
-                        url: scopedByRealm(realm, `authentication/modules?_queryFilter=_id eq "${name}"&_fields=_id`),
+                        url: scopedByRealm(
+                            realm,
+                            `authentication/modules?_queryFilter=${queryFilter}&_fields=_id`),
                         headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" }
                     });
 

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/PoliciesView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/PoliciesView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 
@@ -59,7 +60,7 @@ define([
                 state: BackgridUtils.getState(),
                 queryParams: BackgridUtils.getQueryParams({
                     filterName: "eq",
-                    _queryFilter: [`applicationName+eq+"${encodeURIComponent(this.data.policySetModel.id)}"`]
+                    _queryFilter: [encodeURIComponent(`applicationName eq "${this.data.policySetModel.id}"`)]
                 }),
                 parseState: BackgridUtils.parseState,
                 parseRecords: BackgridUtils.parseRecords,

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/uma/views/resource/BasePage.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/uma/views/resource/BasePage.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -53,10 +54,10 @@ define([
             });
         },
         createLabelCollection (labelId) {
-            var filters = [`resourceOwnerId eq \"${Configuration.loggedUser.get("username")}\"`];
+            var filters = [encodeURIComponent(`resourceOwnerId eq "${Configuration.loggedUser.get("username")}"`)];
 
             if (labelId) {
-                filters.push(`labels eq \"${labelId}\"`);
+                filters.push(encodeURIComponent(`labels eq "${labelId}"`));
             }
 
             return this.createCollection(
@@ -72,6 +73,8 @@ define([
             if (notResourceOwner) {
                 filters[0] = `! ${filters[0]}`;
             }
+
+            filters[0] = encodeURIComponent(filters[0]);
 
             return this.createCollection(
                 RealmHelper.decorateURIWithRealm(`/${Constants.context}/json/__subrealm__/users/${


### PR DESCRIPTION
# About this pull request

As written at comment of Issue #54, There are three similar problems.
Problem 1) Can not edit policy using IE11 (the main title of Issue #54)
  When using IE11 as a client, you can not edit the policy in the admin console.
Problem 2) Can not create authentication module when using IE11
  When using IE11 as a client, you can not create authentication module in the admin console.
Problem 3) Can not display user resource information when using IE11 and enabling UMA provider.
  When using IE11 and enabling UMA provider, you can not display user resource information at user profile screen.

I modified these three problems.
Each problem information is as follows.



# Problem 1 (Can not edit policy using IE11) (the main title of Issue #54)

## Source Code File
openam/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/PoliciesView.js

## Analysis
Not encoded strings ( such as " ) are used at URL when accessing OpenAM.

## Solution
Add encode processing at section of creating the corresponding URL

## Testing
Check if policy can edit in the admin console and the response code of this access is "200 OK", when using IE11 as a client.



# Problem 2 (Can not create authentication module when using IE11)

## Source Code File
openam/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/AuthenticationService.js

## Analysis
Not encoded strings ( such as " ) are used at URL when accessing OpenAM.

## Solution
Add encode processing at section of creating the corresponding URL

## Testing
Check if authntication module create in the admin console and the response code of this access is "200 OK", when using IE11 as a client.



# Problem 3 (Can not display user resource information when using IE11 and enabling UMA provider.)

## Source Code File
openam/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/uma/views/resource/BasePage.js

## Analysis
Not encoded strings ( such as " ) are used at URL when accessing OpenAM.

## Solution
Add encode processing at section of creating the corresponding URL

## Testing
Check if user resource information display at user profile screen and the response code of this access is "200 OK", when using IE11 as a client.