### PR TITLE
Issue #47 Local auth ignores Accept-Language

### DIFF
--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.authentication.modules.saml2;
 

--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
@@ -353,6 +353,11 @@ public class SAML2 extends AMLoginModule {
 
         //generate a sub-login context, owned by this module, and start login sequence to it
         authenticationContext = new AuthContext(realm);
+        authenticationContext.setLocale(getLoginLocale());
+        /* TODO: Some auth methods such as DeskTop SSO require information stored in
+           request/response objects. The last two parameters should be request and response
+           insted of null and null.
+        */  
         authenticationContext.login(AuthContext.IndexType.SERVICE, localChain, null, null, null, null);
 
         return injectCallbacks(null, state);


### PR DESCRIPTION
## Analysis

Login Locale is not specified to the new authContext and the default locale is used instead.

## Solution

Set Login Locale to the new authContext right after it is created.

## Install/Update

none

## Compatibility

none

## Performance

none

## I18N

none

## Testing

See Issue #47 "Steps to reproduce"

## Regression testing

Local authentication screen is displayed in Japanese as expected

