### PR TITLE
Issue #61 OAuth consent page ignores Accept-Language

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/ConsentRequiredResource.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/ConsentRequiredResource.java
@@ -12,9 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corp.
  */
 package org.forgerock.oauth2.restlet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -26,10 +28,13 @@ import org.forgerock.json.JsonValue;
 import org.forgerock.openam.oauth2.OAuth2Constants;
 import org.forgerock.oauth2.core.OAuth2Request;
 import org.forgerock.oauth2.core.exceptions.ResourceOwnerConsentRequired;
+import org.forgerock.openam.oauth2.OAuth2Utils;
 import org.forgerock.openam.rest.service.RouterContextResource;
 import org.forgerock.openam.services.baseurl.BaseURLProviderFactory;
 import org.forgerock.openam.xui.XUIState;
 import org.owasp.esapi.ESAPI;
+import org.restlet.data.Language;
+import org.restlet.data.Preference;
 import org.restlet.data.Reference;
 import org.restlet.ext.servlet.ServletUtils;
 import org.restlet.routing.Router;
@@ -80,6 +85,12 @@ public abstract class ConsentRequiredResource extends RouterContextResource {
         data.put("baseUrl", baseURLProviderFactory.get(request.<String>getParameter("realm"))
                 .getRootURL(ServletUtils.getRequest(getRequest())));
         data.put("saveConsentEnabled", consentRequired.isSaveConsentEnabled());
+        List<String> locale = new ArrayList<>();
+        for (Preference<Language> language : getRequest().getClientInfo().getAcceptedLanguages()) {
+            locale.add(language.getMetadata().getName());
+        }
+        data.put("locale", OAuth2Utils.joinStatic(locale, " "));
+
         return data;
     }
 

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2Utils.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2Utils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corp.
  */
 
 package org.forgerock.openam.oauth2;
@@ -120,7 +121,7 @@ public class OAuth2Utils {
         return !isBlank(val);
     }
 
-    public String join(Iterable<? extends Object> iterable, String delimiter) {
+    public static String joinStatic(Iterable<? extends Object> iterable, String delimiter) {
         if (null != iterable) {
             Iterator<? extends Object> iterator = iterable.iterator();
             if (!iterator.hasNext()) {
@@ -135,6 +136,11 @@ public class OAuth2Utils {
             return buffer.toString();
         }
         return null;
+    }
+
+
+    public String join(Iterable<? extends Object> iterable, String delimiter) {
+        return joinStatic(iterable, delimiter);
     }
 
     public Set<String> split(String string, String delimiter) {

--- a/openam-oauth2/src/main/resources/templates/page/authorize.ftl
+++ b/openam-oauth2/src/main/resources/templates/page/authorize.ftl
@@ -23,6 +23,7 @@
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
   ~ Portions Copyrighted 2014 Nomura Research Institute, Ltd
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corp.
   -->
 <html lang="en">
     <head>
@@ -39,7 +40,7 @@
         <script type="text/javascript">
             pageData = {
                 <#if realm??>realm: "${realm?js_string}",</#if>
-                <#if ui_locales??>locale: "${ui_locales?js_string}",</#if>
+                <#if ui_locales??>locale: "${ui_locales?js_string}",<#elseif locale??>locale: "${locale?js_string}",</#if>
                 baseUrl : "${baseUrl?js_string}/XUI",
                 oauth2Data: {
                     <#if redirect_uri??>redirectUri: "${redirect_uri?js_string}",</#if>

--- a/openam-oauth2/src/main/resources/templates/popup/authorize.ftl
+++ b/openam-oauth2/src/main/resources/templates/popup/authorize.ftl
@@ -23,6 +23,7 @@
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
   ~ Portions Copyrighted 2014 Nomura Research Institute, Ltd
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corp.
   -->
 <html lang="en">
     <head>
@@ -39,7 +40,7 @@
         <script type="text/javascript">
             pageData = {
                 <#if realm??>realm: "${realm?js_string}",</#if>
-                <#if ui_locales??>locale: "${ui_locales?js_string}",</#if>
+                <#if ui_locales??>locale: "${ui_locales?js_string}",<#elseif locale??>locale: "${locale?js_string}",</#if>
                 baseUrl : "${baseUrl?js_string}/XUI",
                 oauth2Data: {
                     <#if redirect_uri??>redirectUri: "${redirect_uri?js_string}",</#if>

--- a/openam-oauth2/src/main/resources/templates/touch/authorize.ftl
+++ b/openam-oauth2/src/main/resources/templates/touch/authorize.ftl
@@ -23,6 +23,7 @@
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
   ~ Portions Copyrighted 2014 Nomura Research Institute, Ltd
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corp.
   -->
 <html lang="en">
     <head>
@@ -39,7 +40,7 @@
         <script type="text/javascript">
             pageData = {
                 <#if realm??>realm: "${realm?js_string}",</#if>
-                <#if ui_locales??>locale: "${ui_locales?js_string}",</#if>
+                <#if ui_locales??>locale: "${ui_locales?js_string}",<#elseif locale??>locale: "${locale?js_string}",</#if>
                 baseUrl : "${baseUrl?js_string}/XUI",
                 oauth2Data: {
                     <#if redirect_uri??>redirectUri: "${redirect_uri?js_string}",</#if>


### PR DESCRIPTION
## Analysis

When consent page is needed, page template "authorize.ftl" is used.
In this "authorize.ftl", only "ui_locales" is referred as locale information.
Also, "ConsentRequiredResource.java" which creates data for "authorize.ftl", 
does not refer browser's locale information (Accept-Language header).


## Solution

On device flow specific page, browser locale information is referred in "DeviceCodeVerificationResource.java". 
And then, this browser locale information data is used in page template "CodeVerificationForm.ftl".

So, add code so as to handle browser locale information,  as the case of device flow specific page mentioned above.


## Testing

See Issue #61 "Steps to reproduce"