### PR TITLE
Issue #121 Can not create a new realm when using IE11

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/models/JSONValues.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/models/JSONValues.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
  /**
@@ -81,8 +82,9 @@ define([
                 if (hasDefaults) { values = ungroupValue(values, "defaults"); }
                 if (hasDynamic) { values = ungroupValue(values, "dynamic"); }
             }
-
-            this.raw = Object.freeze(values);
+            if (values) {
+                this.raw = Object.freeze(values);
+            }
         }
         addInheritance (inheritance) {
             const valuesWithInheritance = _.mapValues(this.raw, (value, key) => ({


### PR DESCRIPTION
## Analysis

If using IE11, JSONValues.js occurs error  and can not render as expected.

JSONValues.js initializes own data using the argument of the constructor. After that, the data is frozen with the `Object.freeze()` method.

And when creating a realm, `undefined` may be passed as an argument of JSONValues constructor. Then `undefined` is also passed to `Object.freeze()` method.
If the browser supports ES2015, `Object.freeze()` will return `undefined`, and the browser wokes fine. However, an error will occur in IE. Because, IE does not support ES2015.

## Solution

Check if the argument is `undefined` before calling `Object.freeze()` in JSONValues

## Testing

* Try #121 "Steps to reproduce"

## Regression testing

* Try #121 "Steps to reproduce" using Edge, Chrome, Firefox