### PR TITLE
Issue #85 Some JSPs redirect to showServerConfig.jsp

### DIFF
--- a/openam-server-only/src/main/webapp/Debug.jsp
+++ b/openam-server-only/src/main/webapp/Debug.jsp
@@ -28,6 +28,7 @@
 
 <%--
    Portions Copyrighted 2010-2014 ForgeRock AS.
+   Portions copyright 2019 Open Source Solution Technology Corporation
 --%>
 
 <%@ page pageEncoding="UTF-8" %>
@@ -75,7 +76,7 @@
 <%@ include file="/WEB-INF/jsp/admincheck.jsp" %>
 <%
 
-    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "showServerConfig.jsp");
+    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "Debug.jsp");
     if (ssoToken == null) {
 %>
 </body></html>

--- a/openam-server-only/src/main/webapp/encode.jsp
+++ b/openam-server-only/src/main/webapp/encode.jsp
@@ -27,6 +27,7 @@
 
 <%--
    Portions copyright 2010-2014 ForgeRock AS.
+   Portions copyright 2019 Open Source Solution Technology Corporation
 --%>
 
 <%@page contentType="text/html; charset=UTF-8" %> 
@@ -60,7 +61,7 @@
 <%@ include file="/WEB-INF/jsp/admincheck.jsp" %>
 <%
 
-    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "showServerConfig.jsp");
+    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "encode.jsp");
     if (ssoToken == null) {
 %>
 </body></html>

--- a/openam-server-only/src/main/webapp/services.jsp
+++ b/openam-server-only/src/main/webapp/services.jsp
@@ -23,6 +23,10 @@
 
 --%>
 
+<%--
+   Portions copyright 2019 Open Source Solution Technology Corporation
+--%>
+
 <%@ page language="java" %>
 <%@ page import="com.iplanet.sso.SSOToken" %>
 <%@ page import="com.sun.identity.sm.*" %>
@@ -175,7 +179,7 @@
 <%@ include file="/WEB-INF/jsp/admincheck.jsp" %>
 <%
 
-    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "showServerConfig.jsp");
+    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "services.jsp");
     if (ssoToken == null) {
 %>
 </body></html>

--- a/openam-server-only/src/main/webapp/ssoadm.jsp
+++ b/openam-server-only/src/main/webapp/ssoadm.jsp
@@ -28,6 +28,7 @@
 
 <%--
    Portions copyright 2010-2014 ForgeRock AS.
+   Portions copyright 2019 Open Source Solution Technology Corporation
 --%>
 
 <%@ page import="com.iplanet.am.util.SystemProperties" %>
@@ -60,7 +61,7 @@
 <%@ include file="/WEB-INF/jsp/admincheck.jsp" %>
 <%
 
-    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "showServerConfig.jsp");
+    SSOToken ssoToken = requireAdminSSOToken(request, response, out, "ssoadm.jsp");
     if (ssoToken == null) {
 %>
 </body></html>


### PR DESCRIPTION
## Analysis

Some JSP pages redirect to showServerConfig.jsp when accessing without logging in.

## Solution

At each JSP files, modify argument of requireAdminSSOToken function from showServerConfig.jsp to each JSP file name.

## Testing

Access each JSP pages without logging in.
Confirm each JSP pages contents are displayed after logging in.

