### PR TITLE
Issue #52 Japanese localization of OATH authentication (FR OATH)

### DIFF
--- a/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
+++ b/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
@@ -195,10 +195,10 @@ public class AuthenticatorOATH extends AMLoginModule {
             debug.message("OATH::init");
         }
         Locale locale = getLoginLocale();
-        bundle = amCache.getResBundle(amAuthOATH, locale);
         if (debug.messageEnabled()) {
             debug.message("ForgeRock Authenticator locale=" + locale);
         }
+        bundle = amCache.getResBundle(amAuthOATH, locale);
         login_header = bundle.getString("login_header");
 
         userName = (String) sharedState.get(getUserKey());

--- a/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
+++ b/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2012-2016 ForgeRock AS.
  * Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.authentication.modules.fr.oath;
@@ -44,7 +45,9 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.security.auth.Subject;
@@ -75,6 +78,10 @@ public class AuthenticatorOATH extends AMLoginModule {
 
     private String userId = null;
     private String userName = null;
+
+    private ResourceBundle bundle = null;
+    private String login_header = null;
+
 
     //static attribute names
     private static final int NUM_CODES = 10;
@@ -189,6 +196,12 @@ public class AuthenticatorOATH extends AMLoginModule {
         if (debug.messageEnabled()) {
             debug.message("OATH::init");
         }
+        Locale locale = getLoginLocale();
+        bundle = amCache.getResBundle(amAuthOATH, locale);
+        if (debug.messageEnabled()) {
+            debug.message("ForgeRock Authenticator locale=" + locale);
+        }
+        login_header = bundle.getString("login_header");
 
         userName = (String) sharedState.get(getUserKey());
         try {
@@ -327,10 +340,10 @@ public class AuthenticatorOATH extends AMLoginModule {
 
                 case REGISTER_DEVICE:
                     if (isOptional) {
-                        replaceHeader(LOGIN_OPT_DEVICE, MODULE_NAME);
+                        replaceHeader(LOGIN_OPT_DEVICE, login_header);
                         return LOGIN_OPT_DEVICE;
                     } else {
-                        replaceHeader(LOGIN_SAVED_DEVICE, MODULE_NAME);
+                        replaceHeader(LOGIN_SAVED_DEVICE, login_header);
                         return LOGIN_SAVED_DEVICE;
                     }
 
@@ -384,7 +397,7 @@ public class AuthenticatorOATH extends AMLoginModule {
                     return LOGIN_NO_DEVICE;
                 }
             } else {
-                replaceHeader(LOGIN_SAVED_DEVICE, MODULE_NAME);
+                replaceHeader(LOGIN_SAVED_DEVICE, login_header);
                 return LOGIN_SAVED_DEVICE;
             }
         }
@@ -410,7 +423,9 @@ public class AuthenticatorOATH extends AMLoginModule {
                 throw new InvalidPasswordException("amAuth", "invalidPasswd", null);
             }
 
-            replaceHeader(state, MODULE_NAME + "Attempt " + (attempt + 1) + " of " + TOTAL_ATTEMPTS);
+            String fmtMsg = bundle.getString("otpcodemiss");
+            String msg = com.sun.identity.shared.locale.Locale.formatMessage(fmtMsg, TOTAL_ATTEMPTS - attempt);
+            replaceHeader(state, msg);
             return state;
         }
 
@@ -435,7 +450,9 @@ public class AuthenticatorOATH extends AMLoginModule {
                 throw new InvalidPasswordException("amAuth", "invalidPasswd", null);
             }
 
-            replaceHeader(state, MODULE_NAME + "Attempt " + (attempt + 1) + " of " + TOTAL_ATTEMPTS);
+            String fmtMsg = bundle.getString("otpcodemiss");
+            String msg = com.sun.identity.shared.locale.Locale.formatMessage(fmtMsg, TOTAL_ATTEMPTS - attempt);
+            replaceHeader(state, msg);
             return state;
         }
     }

--- a/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
+++ b/openam-authentication/openam-auth-fr-oath/src/main/java/org/forgerock/openam/authentication/modules/fr/oath/AuthenticatorOATH.java
@@ -105,8 +105,6 @@ public class AuthenticatorOATH extends AMLoginModule {
     private static final String ISSUER_NAME = "openam-auth-fr-oath-issuer-name";
     private static final int TOTAL_ATTEMPTS = 3;
 
-    private static final String MODULE_NAME = "ForgeRock Authenticator (OATH)";
-
     //module attribute holders
     private String issuerName;
     private int userConfiguredSkippable = 0;

--- a/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH.properties
+++ b/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH.properties
@@ -11,6 +11,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2012-2015 ForgeRock AS.
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 authentication=Authentication Modules
 iPlanetAMAuthAuthenticatorOATHServiceDescription=ForgeRock Authenticator (OATH)
@@ -57,3 +58,5 @@ HOTP=HOTP
 TOTP=TOTP
 authFailed=Authentication Failed
 outOfSync=Device has exceeded maximum clock drift. Please re-register your device.
+login_header=OATH Authenticator
+otpcodemiss=Invalid OTP code. You will be requested to start again after {0} more failure(s).

--- a/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH_ja.properties
+++ b/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH_ja.properties
@@ -22,6 +22,7 @@
 # "Portions Copyrighted [year] [name of copyright owner]"
 #
 # Portions Copyrighted 2015 ForgeRock AS.
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 #
 
 authentication=\u8a8d\u8a3c\u30e2\u30b8\u30e5\u30fc\u30eb
@@ -62,3 +63,5 @@ a511.help.txt=\u3053\u306e\u5c5e\u6027\u306f\u3001\u6642\u9593\u30d9\u30fc\u30b9
 HOTP=HOTP
 TOTP=TOTP
 authFailed=\u8a8d\u8a3c\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
+login_header=OATH Authenticator
+otpcodemiss=\u5165\u529b\u5024\u304c\u8aa4\u3063\u3066\u3044\u307e\u3059\u3002\u3042\u3068{0}\u56de\u9593\u9055\u3048\u308b\u3068\u6700\u521d\u304b\u3089\u3084\u308a\u76f4\u3057\u3068\u306a\u308a\u307e\u3059\u3002

--- a/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
+++ b/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
@@ -14,7 +14,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS.
-  Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ortions Copyrighted 2019 Open Source Solution Technology Corporation
  -->
 
 <!DOCTYPE ModuleProperties PUBLIC "=//iPlanet//Authentication Module Properties XML Interface 1.0 DTD//EN"
@@ -29,10 +29,10 @@
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Register device</Value>
+                    <Value>デバイスの登録</Value>
                 </OptionValue>
                 <OptionValue>
-                    <Value>Skip this step</Value>
+                    <Value>登録しないでログインする</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
@@ -42,7 +42,7 @@
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Register device</Value>
+                    <Value>デバイスの登録</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
@@ -50,41 +50,40 @@
     <!-- For when we're not optional and a device is registered -->
     <Callbacks length="2" order="4" timeout="120" header="#REPLACE#">
         <NameCallback>
-            <Prompt>Enter verification code:</Prompt>
+            <Prompt>ワンタイムパスワードの入力:</Prompt>
         </NameCallback>
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Submit</Value>
+                    <Value>送信</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
     </Callbacks>
     <!-- For registration -->
-    <Callbacks length="3" order="5" timeout="120" header="Register your device with OpenAM">
+    <Callbacks length="3" order="5" timeout="120" header="デバイスの登録">
         <TextOutputCallback>
-            Scan the barcode image below with the ForgeRock Authenticator App. Once registered click the button to
-            enter your verification code and login.
+             お手持ちのスマートフォン等の端末でアプリを起動し、バーコードをスキャンしてください。スキャンしてアカウントが登録されたら「次へ進む」を押してください。
+             現在アプリがインストールされている端末でアクセスしている場合はスキャンせずに「スマートデバイスはこちら」を押すとアカウントを登録することが出来ます。
         </TextOutputCallback>
         <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Login using verification code</Value>
+                    <Value>次へ進む</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
     </Callbacks>
     <!-- For recovery code use -->
-    <Callbacks length="2" order="6" timeout="120" header="OATH Authenticator Emergency Code Used">
+    <Callbacks length="2" order="6" timeout="120" header="リカバリーコードの使用">
         <TextOutputCallback>
-            You have used one of your Emergency OATH Authenticator Codes. Please make sure you have a note of
-            any remaining OATH Authenticator Codes.
+            リカバリーコードを使ってログインを行いました。今回入力したコードはもう使用できません。
         </TextOutputCallback>
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Continue</Value>
+                    <Value>次へ進む</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
@@ -92,15 +91,15 @@
     <!-- For when we're optional, but we just generated a device -->
     <Callbacks length="2" order="7" timeout="120" header="#REPLACE#">
         <NameCallback>
-            <Prompt>Enter verification code:</Prompt>
+            <Prompt>ワンタイムパスワードの入力:</Prompt>
         </NameCallback>
         <ConfirmationCallback>
             <OptionValues>
                 <OptionValue>
-                    <Value>Submit</Value>
+                    <Value>送信</Value>
                 </OptionValue>
                 <OptionValue>
-                    <Value>Skip this step</Value>
+                    <Value>登録しないでログインする</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>

--- a/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
+++ b/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
@@ -14,7 +14,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS.
-  ortions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
  -->
 
 <!DOCTYPE ModuleProperties PUBLIC "=//iPlanet//Authentication Module Properties XML Interface 1.0 DTD//EN"


### PR DESCRIPTION
## Analysis
 'default_ja/AuthenticatorOATH.xml' file does not exist.
Fixed related issues
* Some messages cannot be changed in the properties file
* I want to change the word 'ForgeRock Authenticator (OATH)' that the user sees

## Solution
* Create 'default_en/AuthenticatorOATH.xml' file
* Some messages can be changed in the properties file
* Changed user-visible message word from 'ForgeRock Authenticator (OATH)' to 'OATH Authenticator'


## I18N
Changed only in English and Japanese. Because files exist only in these two languages

## Testing
Test browser language specification in English and Japanese patterns.
Test with on/off pattern of two-factor authentication setting.(Authentication > Setting > General > Two Factor Authentication Mandatory)
* Register the device and login.
* Login with registered device.
* Login using the recovery code.

