### PR TITLE
Issue #11 Several authentication modules do not work if platform cookie domains list is empty.

### DIFF
--- a/openam-authentication/openam-auth-adaptive/src/main/java/org/forgerock/openam/authentication/modules/adaptive/Adaptive.java
+++ b/openam-authentication/openam-auth-adaptive/src/main/java/org/forgerock/openam/authentication/modules/adaptive/Adaptive.java
@@ -22,7 +22,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
  * Portions Copyrighted 2013-2016 Nomura Research Institute, Ltd.
- * Portions Copyrighted 2020-2021 OSSTech Corporation
+ * Portions Copyrighted 2020-2022 OSSTech Corporation
  */
 
 package org.forgerock.openam.authentication.modules.adaptive;
@@ -1078,8 +1078,12 @@ public class Adaptive extends AMLoginModule implements AMPostAuthProcessInterfac
 
     private void addCookieToResponse(HttpServletRequest request, HttpServletResponse response,
             Set<String> cookieDomains, String name, String value, int expire) {
-        for (String domain : cookieDomains) {
-            CookieUtils.addCookieToResponse(request, response, CookieUtils.newCookie(name, value, expire, "/", domain));
+        if (cookieDomains.isEmpty()) {
+            CookieUtils.addCookieToResponse(request, response, CookieUtils.newCookie(name, value, expire, "/", null));
+        } else {
+            for (String domain : cookieDomains) {
+                CookieUtils.addCookieToResponse(request, response, CookieUtils.newCookie(name, value, expire, "/", domain));
+            }
         }
     }
 

--- a/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuth.java
+++ b/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuth.java
@@ -23,7 +23,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2022 OSSTech Corporation
  * Portions Copyrighted 2020 i7a7467
  */
 package org.forgerock.openam.authentication.modules.oauth2;
@@ -226,16 +226,29 @@ public class OAuth extends AMLoginModule {
                 // be used because the framework changes the order of the 
                 // parameters in the query. OAuth2 requires an identical URL 
                 // when retrieving the token
-                for (String domain : domains) {
+                if (domains.isEmpty()) {
                     CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", domain));
+                            CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", null));
                     CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", domain));
+                            CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", null));
                     CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", domain));
+                            CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", null));
                     if (ProviderLogoutURL != null && !ProviderLogoutURL.isEmpty()) {
                         CookieUtils.addCookieToResponse(request, response,
-                                CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", domain));
+                                CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", null));
+                    }
+                } else {
+                    for (String domain : domains) {
+                        CookieUtils.addCookieToResponse(request, response,
+                                CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", domain));
+                        CookieUtils.addCookieToResponse(request, response,
+                                CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", domain));
+                        CookieUtils.addCookieToResponse(request, response,
+                                CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", domain));
+                        if (ProviderLogoutURL != null && !ProviderLogoutURL.isEmpty()) {
+                            CookieUtils.addCookieToResponse(request, response,
+                                    CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", domain));
+                        }
                     }
                 }
 

--- a/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuth.java
+++ b/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuth.java
@@ -227,28 +227,10 @@ public class OAuth extends AMLoginModule {
                 // parameters in the query. OAuth2 requires an identical URL 
                 // when retrieving the token
                 if (domains.isEmpty()) {
-                    CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", null));
-                    CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", null));
-                    CookieUtils.addCookieToResponse(request, response,
-                            CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", null));
-                    if (ProviderLogoutURL != null && !ProviderLogoutURL.isEmpty()) {
-                        CookieUtils.addCookieToResponse(request, response,
-                                CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", null));
-                    }
+                    addCookiesToResponse(request, response, originalUrl, csrfStateTokenId, ProviderLogoutURL, null);
                 } else {
                     for (String domain : domains) {
-                        CookieUtils.addCookieToResponse(request, response,
-                                CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", domain));
-                        CookieUtils.addCookieToResponse(request, response,
-                                CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", domain));
-                        CookieUtils.addCookieToResponse(request, response,
-                                CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", domain));
-                        if (ProviderLogoutURL != null && !ProviderLogoutURL.isEmpty()) {
-                            CookieUtils.addCookieToResponse(request, response,
-                                    CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", domain));
-                        }
+                        addCookiesToResponse(request, response, originalUrl, csrfStateTokenId, ProviderLogoutURL, domain);
                     }
                 }
 
@@ -527,6 +509,21 @@ public class OAuth extends AMLoginModule {
         }
         
         throw new AuthLoginException(BUNDLE_NAME, "unknownState", null);
+    }
+
+    private void addCookiesToResponse(HttpServletRequest request, HttpServletResponse response,
+            StringBuilder originalUrl, String csrfStateTokenId, String ProviderLogoutURL, String domain) {
+
+        CookieUtils.addCookieToResponse(request, response,
+                CookieUtils.newCookie(COOKIE_PROXY_URL, proxyURL, "/", domain));
+        CookieUtils.addCookieToResponse(request, response,
+                CookieUtils.newCookie(COOKIE_ORIG_URL, originalUrl.toString(), "/", domain));
+        CookieUtils.addCookieToResponse(request, response,
+                CookieUtils.newCookie(NONCE_TOKEN_ID, csrfStateTokenId, "/", domain));
+        if (ProviderLogoutURL != null && !ProviderLogoutURL.isEmpty()) {
+            CookieUtils.addCookieToResponse(request, response,
+                    CookieUtils.newCookie(COOKIE_LOGOUT_URL, ProviderLogoutURL, "/", domain));
+        }
     }
 
     private String createAuthorizationState() {

--- a/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuthProxy.java
+++ b/openam-authentication/openam-auth-oauth2/src/main/java/org/forgerock/openam/authentication/modules/oauth2/OAuthProxy.java
@@ -22,7 +22,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
- * Portions Copyrighted 2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2020-2022 OSSTech Corporation
  */
 package org.forgerock.openam.authentication.modules.oauth2;
 
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.Map;
+import java.util.Set;
 
 import com.sun.identity.authentication.client.AuthClientUtils;
 import com.sun.identity.shared.encode.CookieUtils;
@@ -133,8 +134,13 @@ public class OAuthProxy  {
 
         OAuthUtil.debugMessage("OAuthProxy.toPostForm: removing cookie " + COOKIE_ORIG_URL);
 
-        for (String cookieDomain : AuthClientUtils.getCookieDomainsForRequest(req)) {
-            CookieUtils.addCookieToResponse(req, res, CookieUtils.newCookie(COOKIE_ORIG_URL, "", 0, "/", cookieDomain));
+        Set<String> domains = AuthClientUtils.getCookieDomainsForRequest(req);
+        if (domains.isEmpty()) {
+            CookieUtils.addCookieToResponse(req, res, CookieUtils.newCookie(COOKIE_ORIG_URL, "", 0, "/", null));
+        } else {
+            for (String cookieDomain : domains) {
+                CookieUtils.addCookieToResponse(req, res, CookieUtils.newCookie(COOKIE_ORIG_URL, "", 0, "/", cookieDomain));
+            }
         }
         out.println(html.toString());
     }

--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2019-2020 Open Source Solution Technology Corporation
+ * Portions copyright 2019-2022 OSSTech Corporation
  */
 package org.forgerock.openam.authentication.modules.saml2;
 
@@ -443,9 +443,14 @@ public class SAML2 extends AMLoginModule {
         }
 
         // Set the return URL Cookie
-        for (String domain : domains) {
+        if (domains.isEmpty()) {
             CookieUtils.addCookieToResponse(request, response,
-                    CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, originalUrl.toString(), "/", domain));
+                    CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, originalUrl.toString(), "/", null));
+        } else {
+            for (String domain : domains) {
+                CookieUtils.addCookieToResponse(request, response,
+                        CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, originalUrl.toString(), "/", domain));
+            }
         }
     }
 
@@ -456,9 +461,14 @@ public class SAML2 extends AMLoginModule {
         final Set<String> domains = AuthClientUtils.getCookieDomainsForRequest(request);
 
         // Set the return URL Cookie
-        for (String domain : domains) {
+        if (domains.isEmpty()) {
             CookieUtils.addCookieToResponse(request, response,
-                    CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, "", 0, "/", domain));
+                    CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, "", 0, "/", null));
+        } else {
+            for (String domain : domains) {
+                CookieUtils.addCookieToResponse(request, response,
+                        CookieUtils.newCookie(Constants.AM_LOCATION_COOKIE, "", 0, "/", domain));
+            }
         }
     }
 


### PR DESCRIPTION
## Analysis

In the current authentication modules (SAML2, OAuth2 and AdaptiveRisk), 
cookies are set only if the setting of the cookie domains is not empty.


## Solution

Set cookies without domain attribute if the setting of the cookie domains is empty.


## Testing

[SAML2]

　See Issue #11 "Steps to reproduce"

[OAuth2]

1. Set up OpenAM with OAuth2 authentication module
2. Delete all entries in System -> Platform -> Cookie Domains
3. Call OAuth2 authentication module
4. Authenticate and authorize with OAuth2 Provider
5. (Before correction) Error message "Request not valid" comes out on OAuthProxy.jsp access
   (After correction) OAuth2 authentication succeeds
   
[AdaptiveRisk]

1. Set up OpenAM with AdaptiveRisk authentication module
2. On the AdaptiveRisk authentication module's configuration, use
  "Save Cookie Value on Successful Login" or
  "Save time of Successful Login" or 
  "Save Device Registration on Successful Login"
3. Delete all entries in System -> Platform -> Cookie Domains
4. Call AdaptiveRisk authentication module and proceed authentication
5. (Before correction) AdaptiveRisk's cookies are NOT set on the response of authentication
   (After correction) AdaptiveRisk's cookies are set on the response of authentication
