### PR TITLE
Issue #125 An improvement on Membership Condition console

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrArrayView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrArrayView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2023 OSSTech Corporation
  */
 
 define([
@@ -118,8 +119,13 @@ define([
                                         return obj === item;
                                     });
 
-                                    view.data.itemData.subjectValues = _.without(view.data.itemData.subjectValues,
-                                        universalid);
+                                    if (data.itemData.type === "AMIdentityMembership") {
+                                        view.data.itemData.amIdentityName = _.without(view.data.itemData.amIdentityName,
+                                            universalid);
+                                    } else {
+                                        view.data.itemData.subjectValues = _.without(view.data.itemData.subjectValues,
+                                            universalid);
+                                    }
                                     delete view.data.hiddenData[type][universalid];
                                 }
                             });
@@ -174,7 +180,11 @@ define([
         getUniversalId (item, type) {
             var self = this;
             PoliciesService.getUniversalId(item, type).done(function (subject) {
-                self.data.itemData.subjectValues = _.union(self.data.itemData.subjectValues, subject.universalid);
+                if (self.data.itemData.type === "AMIdentityMembership") {
+                    self.data.itemData.amIdentityName = _.union(self.data.itemData.amIdentityName, subject.universalid);
+                } else {
+                    self.data.itemData.subjectValues = _.union(self.data.itemData.subjectValues, subject.universalid);
+                }
                 self.data.hiddenData[type][subject.universalid[0]] = item;
             });
         },

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
@@ -1158,7 +1158,9 @@
                         "AMIdentityMembership": {
                             "title": "Identity Membership",
                             "props": {
-                                "amIdentityName": "AM Identity Name"
+                                "amIdentityName": "AM Identity Name",
+                                "users" : "Users",
+                                "groups": "Groups"
                             }
                         },
                         "AuthLevel": {

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
@@ -1158,7 +1158,9 @@
                         "AMIdentityMembership": {
                             "title": "アイデンティティメンバーシップ",
                             "props": {
-                                "amIdentityName": "AM アイデンティティ名"
+                                "amIdentityName": "AM アイデンティティ名",
+                                "users" : "ユーザー対象",
+                                "groups": "グループ対象"
                             }
                         },
                         "AuthLevel": {


### PR DESCRIPTION
## Analysis

Adding an "Identity membership" environment condition to a policy in the XUI requires specifying entries in the universal Id format.  This is time consuming and prone to making mistakes.

## Solution

Adding a "Subject condition" to a policy is much easier.  By entering a first few characters, candidates are listed and we only need to choose from them.  "Identity membership" condition should work in the same way.

## Install/Update

none

## Compatibility

none

## Performance

none

## I18N

none

## Testing

- Editing membership condition using the console
    - User CRUD
    - Group CRUD

## Regression testing

- Membership condition defined in a policy
    - User condition works
    - Group condition works
