### PR TITLE
Issue #63 SAML2 Auth Module does not accept SAML2 AuthResponse with no SessionIndex

### DIFF
--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2.java
@@ -358,7 +358,7 @@ public class SAML2 extends AMLoginModule {
         /* TODO: Some auth methods such as DeskTop SSO require information stored in
            request/response objects. The last two parameters should be request and response
            insted of null and null.
-        */  
+        */
         authenticationContext.login(AuthContext.IndexType.SERVICE, localChain, null, null, null, null);
 
         return injectCallbacks(null, state);
@@ -621,7 +621,6 @@ public class SAML2 extends AMLoginModule {
         }
 
         //we need the following for idp initiated slo as well as sp, so always include it
-        setUserSessionProperty(SAML2Constants.SESSION_INDEX, sessionIndex);
         setUserSessionProperty(SAML2Constants.IDPENTITYID, entityName);
         setUserSessionProperty(SAML2Constants.SPENTITYID, SPSSOFederate.getSPEntityId(metaAlias));
         setUserSessionProperty(SAML2Constants.METAALIAS, metaAlias);
@@ -631,6 +630,13 @@ public class SAML2 extends AMLoginModule {
         setUserSessionProperty(Constants.REQUEST_ID, respInfo.getResponse().getInResponseTo());
         setUserSessionProperty(SAML2Constants.BINDING, binding);
         setUserSessionProperty(Constants.CACHE_KEY, storageKey);
+
+        // SessionIndex is optional
+        // if idp support single logout, idp must include SessionIndex attribute
+        if (sessionIndex != null) {
+            setUserSessionProperty(SAML2Constants.SESSION_INDEX, sessionIndex);
+        }
+
     }
 
     /**

--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2ResponseData.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2ResponseData.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2015 ForgeRock AS.
+* Portions copyright 2019 Open Source Solution Technology Corporation
 */
 package org.forgerock.openam.authentication.modules.saml2;
 
@@ -46,7 +47,7 @@ public class SAML2ResponseData {
      * @param responseInfo Response Information pertaining to the authentication.
      */
     public SAML2ResponseData(String sessionIndex, Subject subject, Assertion assertion, ResponseInfo responseInfo) {
-        Reject.ifNull(sessionIndex, subject, assertion, responseInfo);
+        Reject.ifNull(subject, assertion, responseInfo);
 
         this.subject = subject;
         this.assertion = assertion;


### PR DESCRIPTION
## Analysis

With the saml2 authentication module,
sessionindex is required in saml response.

## Solution

Fix saving sessionindex and null check.

## Testing

* Try #63 "Steps to reproduce".

## Regression testing

* Try #63 "Steps to reproduce".
   At that time, in the SalesForce console Enable SingleLogout for SP(OpenAM).
   In addition, entere the SingleLogout url and bind.
  Then sessionindex is included in the saml response.
   

