### PR TITLE
Issue #91 AMUncaughtException occurs in the configuration screen for Google Apps

### DIFF
--- a/openam-console/src/main/java/com/sun/identity/console/task/ConfigureGoogleAppsCompleteViewBean.java
+++ b/openam-console/src/main/java/com/sun/identity/console/task/ConfigureGoogleAppsCompleteViewBean.java
@@ -25,6 +25,7 @@
  * $Id: ConfigureGoogleAppsCompleteViewBean.java,v 1.7 2009/05/07 21:31:45 asyhuang Exp $
  *
  * Portions Copyrighted 2015 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.console.task;
 
@@ -37,6 +38,7 @@ import com.iplanet.jato.view.event.RequestInvocationEvent;
 import com.sun.identity.console.XuiRedirectHelper;
 import com.sun.identity.console.base.AMPrimaryMastHeadViewBean;
 import com.sun.identity.console.base.AMPropertySheet;
+import com.sun.identity.console.base.model.AMAdminConstants;
 import com.sun.identity.console.base.model.AMConsoleException;
 import com.sun.identity.console.base.model.AMModel;
 import com.sun.identity.console.base.model.AMPropertySheetModel;
@@ -125,6 +127,7 @@ public class ConfigureGoogleAppsCompleteViewBean
             super.beginDisplay(event);
             HttpServletRequest req = getRequestContext().getRequest();
             String realm = req.getParameter("realm");
+            setPageSessionAttribute(AMAdminConstants.CURRENT_REALM, realm);
             String entityId = req.getParameter("idp");
             TaskModel model = (TaskModel) getModelInternal();
             Map values = model.getConfigureGoogleAppsURLs(realm, entityId);

--- a/openam-console/src/main/java/com/sun/identity/console/task/ConfigureSalesForceAppsCompleteViewBean.java
+++ b/openam-console/src/main/java/com/sun/identity/console/task/ConfigureSalesForceAppsCompleteViewBean.java
@@ -25,6 +25,7 @@
  * $Id: ConfigureSalesForceAppsCompleteViewBean.java,v 1.3 2009/07/28 17:45:40 babysunil Exp $
  *
  * Portions Copyrighted 2013-2015 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.console.task;
 
@@ -35,6 +36,7 @@ import com.iplanet.jato.view.event.DisplayEvent;
 import com.iplanet.jato.view.event.RequestInvocationEvent;
 import com.sun.identity.console.base.AMPrimaryMastHeadViewBean;
 import com.sun.identity.console.base.AMPropertySheet;
+import com.sun.identity.console.base.model.AMAdminConstants;
 import com.sun.identity.console.base.model.AMConsoleException;
 import com.sun.identity.console.base.model.AMModel;
 import com.sun.identity.console.base.model.AMPropertySheetModel;
@@ -123,6 +125,7 @@ public class ConfigureSalesForceAppsCompleteViewBean
             super.beginDisplay(event);
             HttpServletRequest req = getRequestContext().getRequest();
             String realm = req.getParameter("realm");
+            setPageSessionAttribute(AMAdminConstants.CURRENT_REALM, realm);
             String idp = req.getParameter("idp");
             String attrMapp = req.getParameter("attrMapp");
             String spEntityId = req.getParameter(ENTITY_ID);
@@ -191,6 +194,8 @@ public class ConfigureSalesForceAppsCompleteViewBean
                 ConfigureSalesForceAppsFinishWarningViewBean vb =
                         (ConfigureSalesForceAppsFinishWarningViewBean) getViewBean(
                         ConfigureSalesForceAppsFinishWarningViewBean.class);
+                String realm = (String) getPageSessionAttribute(AMAdminConstants.CURRENT_REALM);
+                vb.setPageSessionAttribute(AMAdminConstants.CURRENT_REALM, realm);
                 vb.forwardTo(getRequestContext());
             }
         } catch (AMConsoleException e) {

--- a/openam-console/src/main/java/com/sun/identity/console/task/ConfigureSalesForceAppsFinishWarningViewBean.java
+++ b/openam-console/src/main/java/com/sun/identity/console/task/ConfigureSalesForceAppsFinishWarningViewBean.java
@@ -25,6 +25,7 @@
  * $Id: ConfigureSalesForceAppsFinishWarningViewBean.java,v 1.1 2009/07/28 17:45:20 babysunil Exp $
  *
  * Portions Copyrighted 2015 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 package com.sun.identity.console.task;
@@ -80,7 +81,7 @@ public class ConfigureSalesForceAppsFinishWarningViewBean
         int idx = html.lastIndexOf("</div>");
         String redirectUrl;
         if (XuiRedirectHelper.isXuiAdminConsoleEnabled()) {
-            String realm = RequestManager.getRequestContext().getRequest().getParameter("realm");
+            String realm = XuiRedirectHelper.getRedirectRealm(this);
             redirectUrl = "../XUI#realms/" + Uris.urlEncodePathElement(realm) + "/dashboard";
         } else {
             redirectUrl = "../task/Home";

--- a/openam-console/src/main/java/com/sun/identity/console/task/RedirectToRealmHomeViewBean.java
+++ b/openam-console/src/main/java/com/sun/identity/console/task/RedirectToRealmHomeViewBean.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package com.sun.identity.console.task;
@@ -34,7 +35,8 @@ public abstract class RedirectToRealmHomeViewBean extends AMPrimaryMastHeadViewB
         if (XuiRedirectHelper.isXuiAdminConsoleEnabled()) {
             RequestContext rc = RequestManager.getRequestContext();
             try {
-                String realm = URLEncoder.encode(rc.getRequest().getParameter("realm"), "UTF-8");
+                String redirectRealm = XuiRedirectHelper.getRedirectRealm(this);
+                String realm = URLEncoder.encode(redirectRealm, "UTF-8");
                 rc.getResponse().sendRedirect("../XUI#realms/" + realm + "/dashboard");
             } catch (UnsupportedEncodingException e) {
                 throw new IllegalStateException("UTF-8 not supported", e);


### PR DESCRIPTION
## Analysis

After pressing "Finish" button on the Google Apps settings complete page, 
it is expected to redirect to the realm's dashboard page.
But on the corresponding code, NullPointerException occered because 
it failed to acquire realm information.


## Solution

Fix code to acquire appropriate realm information by using "PageSessionAttribute".

Not only the Gooble Apps setting but also the Salesforce setting has the same problem.
So it is fixed on this branch in the same way.


## Testing

See Issue #91 "Steps to reproduce"