### PR TITLE
Issue #137 Display of authentication failure screen is unstable

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -68,10 +69,6 @@ define([
                     }
                 }
             }, function (failedStage, errorMsg) {
-                if (failedStage > 1) {
-                    // re-render login form, sending back to the start of the process.
-                    ViewManager.refresh();
-                }
                 errorCallback(errorMsg);
             });
         });


### PR DESCRIPTION
## Analysis

For example, if a multi-factor authentication chain is configured, an authentication failure screen will be displayed if the second authentication fails. However, it seems that the login screen is being drawn at the same time. As a result, the screen display becomes unstable.

The authentication process starts from the beginning by clicking the link on the authentication failure screen. There is no need to redraw the login screen when authentication fails.

## Solution

Do not redraw the login screen when authentication fails.

## Testing

* Try #137 "Steps to reproduce"