### PR TITLE
Issue #46 the local authentication screen is not focused

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -476,9 +477,13 @@ define([
 
                 // Magic number 4 is for a <script>, taken from ScriptTextOutputCallback.java
                 if (options.type.value === "4") {
-                    result += renderPartial("ScriptTextOutput", {
-                        messageValue: options.message.value
-                    });
+                    if (options.message.value === "PLACEHOLDER") {
+                        result += renderPartial("ScriptTextOutput", {});
+                    } else {
+                        result += renderPartial("ScriptTextOutput", {
+                            messageValue: options.message.value
+                        });
+                    }
                 } else {
                     result += renderPartial("TextOutput", {
                         typeValue: options.type.value,


### PR DESCRIPTION
## Analysis

The callback definition for local authentication of SAML2 authentication module has placeholders as follows. Then, placeholders are replaced according to the authentication chain to be called.
However, many authentications use only a few callbacks. Therefore, some placeholders will remain.

```
    <Callbacks length="10" order="3" timeout="120" header="#REPLACE#">
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
        <TextOutputCallback messageType="script">PLACEHOLDER</TextOutputCallback>
    </Callbacks>
```

And since XUI does not recognize these placeholders, it generates the following invalid script tag. As a result, the focus does not work in Firefox.

```
<script type="text/javascript">
if (document.getElementsByClassName("button")[0] != undefined) {
    document.getElementsByClassName("button")[0].style.visibility = "hidden";
}
PLACEHOLDER
</script>
```

## Solution

Remove extra placeholders in XUI.

## Testing

* Try #46 "Steps to reproduce" using Firefox

## Regression testing

* Try #46 "Steps to reproduce" using Edge, Chrome