### PR TITLE
Issue #58 Unexpected screen is displayed when the authentication chain fails

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/config/routes/AMRoutesConfig.js
+++ b/openam-ui/openam-ui-ria/src/main/js/config/routes/AMRoutesConfig.js
@@ -12,13 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([], function () {
     return {
         continuePasswordReset: {
             view: "org/forgerock/openam/ui/user/anonymousProcess/PasswordResetView",
-            url: /continuePasswordReset(\/[^&]*)(&.+)?/,
+            url: /^continuePasswordReset(\/[^&]*)(&.+)?/,
             pattern: "continuePasswordReset??",
             forceUpdate: true,
             defaults: ["/", ""],
@@ -26,7 +27,7 @@ define([], function () {
         },
         continueSelfRegister: {
             view: "org/forgerock/openam/ui/user/anonymousProcess/SelfRegistrationView",
-            url: /continueRegister(\/[^&]*)(&.+)?/,
+            url: /^continueRegister(\/[^&]*)(&.+)?/,
             pattern: "continueRegister??",
             forceUpdate: true,
             defaults: ["/", ""],
@@ -53,21 +54,21 @@ define([], function () {
         },
         loggedOut: {
             view: "org/forgerock/openam/ui/user/login/RESTLogoutView",
-            url: /loggedOut([^&]+)?(&.+)?/,
+            url: /^loggedOut([^&]+)?(&.+)?/,
             pattern: "loggedOut??",
             defaults: ["/", ""],
             argumentNames: ["realm", "additionalParameters"]
         },
         loginFailure: {
             view: "org/forgerock/openam/ui/user/login/LoginFailureView",
-            url: /failedLogin([^&]+)?(&.+)?/,
+            url: /^failedLogin([^&]+)?(&.+)?/,
             pattern: "failedLogin??",
             defaults: ["/", ""],
             argumentNames: ["realm", "additionalParameters"]
         },
         sessionExpired: {
             view: "org/forgerock/openam/ui/user/login/SessionExpiredView",
-            url: /sessionExpired([^&]+)?(&.+)?/,
+            url: /^sessionExpired([^&]+)?(&.+)?/,
             pattern: "sessionExpired??",
             defaults: ["/", ""],
             argumentNames: ["realm", "additionalParameters"]

--- a/openam-ui/openam-ui-ria/src/main/js/config/routes/admin/GlobalRoutes.js
+++ b/openam-ui/openam-ui-ria/src/main/js/config/routes/admin/GlobalRoutes.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -20,14 +21,14 @@ define([
     const routes = {
         listAuthenticationSettings: {
             view: "org/forgerock/openam/ui/admin/views/configuration/authentication/ListAuthenticationView",
-            url: /configure\/authentication$/,
+            url: /^configure\/authentication$/,
             pattern: "configure/authentication",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         editAuthenticationSettings: {
             view: "org/forgerock/openam/ui/admin/views/configuration/authentication/EditGlobalAuthenticationView",
-            url: /configure\/authentication\/([^\/]+)/,
+            url: /^configure\/authentication\/([^\/]+)/,
             pattern: "configure/authentication/?",
             role: "ui-global-admin",
             navGroup: "admin"
@@ -65,42 +66,42 @@ define([
         },*/
         listSites: {
             view: "org/forgerock/openam/ui/admin/views/deployment/sites/ListSitesView",
-            url: /deployment\/sites$/,
+            url: /^deployment\/sites$/,
             pattern: "deployment/sites",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         editSite: {
             view: "org/forgerock/openam/ui/admin/views/deployment/sites/EditSiteView",
-            url: /deployment\/sites\/edit\/([^\/]+)/,
+            url: /^deployment\/sites\/edit\/([^\/]+)/,
             pattern: "deployment/sites/edit/?",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         newSite: {
             view: "org/forgerock/openam/ui/admin/views/deployment/sites/NewSiteView",
-            url: /deployment\/sites\/new/,
+            url: /^deployment\/sites\/new/,
             pattern: "deployment/sites/new",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         listServers: {
             view: "org/forgerock/openam/ui/admin/views/deployment/servers/ListServersView",
-            url: /deployment\/servers$/,
+            url: /^deployment\/servers$/,
             pattern: "deployment/servers",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         newServer: {
             view: "org/forgerock/openam/ui/admin/views/deployment/servers/NewServerView",
-            url: /deployment\/servers\/new$/,
+            url: /^deployment\/servers\/new$/,
             pattern: "deployment/servers/new",
             role: "ui-global-admin",
             navGroup: "admin"
         },
         cloneServer: {
             view: "org/forgerock/openam/ui/admin/views/deployment/servers/NewServerView",
-            url: /deployment\/servers\/clone\/([^\/]+)/,
+            url: /^deployment\/servers\/clone\/([^\/]+)/,
             pattern: "deployment/servers/clone/?",
             role: "ui-global-admin",
             navGroup: "admin"


### PR DESCRIPTION
## Analysis

XUI displays each screen according to the URL pattern of `RoutesConfig`. They are defined as regular expression in some settings, but don't consider the beginning of the string. As a result, it may match the fragment's goto parameter. After that, XUI displays an unexpected screen.

## Solution

Fix routing rules

## Testing

* Try #58 "Steps to reproduce" with openam-jp/forgerock-ui#4