### PR TITLE
Issue #40 SAML2 authentication does not work when SAML2 failover is enabled

### DIFF
--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/profile/ResponseInfo.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/profile/ResponseInfo.java
@@ -25,6 +25,7 @@
  * $Id: ResponseInfo.java,v 1.6 2009/06/17 03:09:13 exu Exp $
  *
  * Portions Copyrighted 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.saml2.profile;
 
@@ -49,6 +50,12 @@ public class ResponseInfo extends CacheObject {
     private String sessionIndex = null;
     private boolean isLocalLogin = false;
 
+    /**
+     * Default constructor for deserialization.
+     */
+    public ResponseInfo() {
+    }
+    
     /**
      * Constructor creates the ResponseInfo.
      * @param response the Response

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/Response.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/Response.java
@@ -24,14 +24,17 @@
  *
  * $Id: Response.java,v 1.2 2008/06/25 05:47:57 qcheng Exp $
  *
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 
 
 package com.sun.identity.saml2.protocol;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import com.sun.identity.saml2.common.SAML2Exception;
+import com.sun.identity.saml2.protocol.impl.ResponseImpl;
 
 /**
  * The <code>Response</code> message element is used when a response consists
@@ -53,6 +56,7 @@ import com.sun.identity.saml2.common.SAML2Exception;
  *
  * @supported.all.api
  */
+@JsonDeserialize(as=ResponseImpl.class)
 public interface Response extends StatusResponse {
 
     /**

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/Status.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/Status.java
@@ -24,12 +24,15 @@
  *
  * $Id: Status.java,v 1.2 2008/06/25 05:47:58 qcheng Exp $
  *
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 
 package com.sun.identity.saml2.protocol;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sun.identity.saml2.common.SAML2Exception;
+import com.sun.identity.saml2.protocol.impl.StatusImpl;
 
 /**
  * This class represents the <code>StatusType</code> complex type in
@@ -52,6 +55,7 @@ import com.sun.identity.saml2.common.SAML2Exception;
  * @supported.all.api
  */
 
+@JsonDeserialize(as=StatusImpl.class)
 public interface Status {
     
     /**

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/StatusCode.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/StatusCode.java
@@ -24,12 +24,15 @@
  *
  * $Id: StatusCode.java,v 1.2 2008/06/25 05:47:58 qcheng Exp $
  *
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 
 
 package com.sun.identity.saml2.protocol;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sun.identity.saml2.common.SAML2Exception;
+import com.sun.identity.saml2.protocol.impl.StatusCodeImpl;
 
 /**
  * This class represents the <code>StatusCodeType</code> complex type in
@@ -53,6 +56,7 @@ import com.sun.identity.saml2.common.SAML2Exception;
  * @supported.all.api
  */
 
+@JsonDeserialize(as=StatusCodeImpl.class)
 public interface StatusCode {
     
     /**


### PR DESCRIPTION
## Analysis

Deserialization fails because,

- `ResponseInfo` class does not have the default constructor.

- Concrete types for `Response`, `Status` and `StatusCode` interfaces can not be determined during deserialization.

## Solution

- Add the default constructor to `ResponseInfo`  class.

- Add `@JsonDeserialize(as=...)` annotation to `Response`, `Status` and `StatusCode` interfaces.

During an internal review,  it was point out that interface should not have a reference to its implementation.  Using Jackson MixIn annotations instead would be a better solution.  Since `@JsonDeserialize` is being used in other places in SAML2 module, we decided to do the same for this fix.  We are planning to refactor this module later.

## Install/Update

None.

## Compatibility

None.

## Performance

None.

## I18N

None.

## Testing

See Issue #40 Steps to reproduce.

## Regression testing

SAML2 authentication works when SAML2 failover is disabled.
