### PR TITLE
Issue #60 Support RSA-OAEP for SAML Assertion Encryption

### DIFF
--- a/openam-core/src/main/resources/serverAttributeMap.properties
+++ b/openam-core/src/main/resources/serverAttributeMap.properties
@@ -25,6 +25,7 @@
 # $Id: serverAttributeMap.properties,v 1.10 2010/01/08 22:41:28 exu Exp $
 #
 # Portions Copyrighted 2011-2016 ForgeRock AS.
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 #
 
 com.sun.identity.plugin.datastore.class.default=sunFAMFederationCommon@10@DatastoreClass
@@ -38,6 +39,7 @@ com.sun.identity.saml.xmlsig.keyprovider.class=sunFAMFederationCommon@10@KeyProv
 com.sun.identity.saml.checkcert=sunFAMFederationCommon@10@CheckCert
 com.sun.identity.saml.xmlsig.c14nMethod=sunFAMFederationCommon@10@CannonicalizationAlgorithm
 com.sun.identity.saml.xmlsig.xmlSigAlgorithm=sunFAMFederationCommon@10@SignatureAlgorithm
+jp.openam.saml.xmlenc.xmlEncKeyTransportAlgorithm=sunFAMFederationCommon@10@EncryptionKeyTransportAlgorithm
 com.sun.identity.saml.xmlsig.digestAlgorithm=sunFAMFederationCommon@10@DigestAlgorithm
 org.forgerock.openam.saml2.query.signature.alg.rsa=sunFAMFederationCommon@10@QuerySignatureAlgorithmRSA
 org.forgerock.openam.saml2.query.signature.alg.dsa=sunFAMFederationCommon@10@QuerySignatureAlgorithmDSA

--- a/openam-federation/OpenFM/src/main/resources/famFederationCommon.properties
+++ b/openam-federation/OpenFM/src/main/resources/famFederationCommon.properties
@@ -26,6 +26,7 @@
 #
 
 # Portions Copyrighted 2011-2016 ForgeRock AS.
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 sunFAMFederationCommon=Common Federation Configuration
 a101=Datastore SPI implementation class
@@ -101,6 +102,11 @@ a1152=Query String signature algorithm (DSA)
 a1152.help=The default signature algorithm to use in case of DSA keys.
 a1153=Query String signature algorithm (EC)
 a1153.help=The default signature algorithm to use in case of EC keys.
+a1154=XML encryption key transport algorithm
+http\://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p=http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p
+http\://www.w3.org/2009/xmlenc11#rsa-oaep=http://www.w3.org/2009/xmlenc11#rsa-oaep
+http\://www.w3.org/2001/04/xmlenc#rsa-1_5=http://www.w3.org/2001/04/xmlenc#rsa-1_5
+a1154.help=This algorithm is used to encrypt the secret key if encrypting XML.
 a116=XML transformation algorithm
 http\://www.w3.org/2001/10/xml-exc-c14n#=http://www.w3.org/2001/10/xml-exc-c14n#
 http\://www.w3.org/2001/10/xml-exc-c14n#WithComments=http://www.w3.org/2001/10/xml-exc-c14n#WithComments

--- a/openam-federation/OpenFM/src/main/resources/ja_JP/famFederationCommon_ja.properties
+++ b/openam-federation/OpenFM/src/main/resources/ja_JP/famFederationCommon_ja.properties
@@ -26,7 +26,7 @@
 #
 
 # Portions Copyrighted 2012 ForgeRock Inc
-# Portions Copyrighted 2012 Open Source Solution Technology Corporation
+# Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
 
 sunFAMFederationCommon=\u5171\u901a\u9023\u643a\u8a2d\u5b9a
 a101=\u30c7\u30fc\u30bf\u30b9\u30c8\u30a2 SPI \u5b9f\u88c5\u30af\u30e9\u30b9
@@ -90,6 +90,11 @@ http\://www.w3.org/2001/04/xmldsig-more#hmac-sha256=http://www.w3.org/2001/04/xm
 http\://www.w3.org/2001/04/xmldsig-more#hmac-sha384=http://www.w3.org/2001/04/xmldsig-more#hmac-sha384
 http\://www.w3.org/2001/04/xmldsig-more#hmac-sha512=http://www.w3.org/2001/04/xmldsig-more#hmac-sha512
 a115.help=XML \u6587\u66f8\u3092\u7f72\u540d\u3059\u308b\u305f\u3081\u306b\u4f7f\u7528\u3055\u308c\u308b\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0\u3002
+a1154=XML \u6697\u53f7\u5316\u9375\u8ee2\u9001\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0
+http\://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p=http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p
+http\://www.w3.org/2009/xmlenc11#rsa-oaep=http://www.w3.org/2009/xmlenc11#rsa-oaep
+http\://www.w3.org/2001/04/xmlenc#rsa-1_5=http://www.w3.org/2001/04/xmlenc#rsa-1_5
+a1154.help=\u3053\u306e\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0\u306f XML \u3092\u6697\u53f7\u5316\u3059\u308b\u5834\u5408\u306b\u79d8\u5bc6\u9375\u3092\u6697\u53f7\u5316\u3059\u308b\u305f\u3081\u306b\u5229\u7528\u3057\u307e\u3059\u3002
 a116=XML \u5909\u63db\u30a2\u30eb\u30b4\u30ea\u30ba\u30e0
 http\://www.w3.org/2001/10/xml-exc-c14n#=http://www.w3.org/2001/10/xml-exc-c14n#
 http\://www.w3.org/2001/10/xml-exc-c14n#WithComments=http://www.w3.org/2001/10/xml-exc-c14n#WithComments

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Constants.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/common/SAML2Constants.java
@@ -25,6 +25,7 @@
  * $Id: SAML2Constants.java,v 1.44 2009/11/24 21:53:02 madan_ranganath Exp $
  *
  * Portions Copyrighted 2010-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.saml2.common;
 
@@ -953,6 +954,12 @@ public interface SAML2Constants {
          "com.sun.identity.saml.xmlsig.xmlSigAlgorithm";
     public String DIGEST_ALGORITHM =
          "com.sun.identity.saml.xmlsig.digestAlgorithm";
+
+    /**
+     * Property name of XML encryption key transport algorithms.
+     */
+    public String XMLENC_KEY_TRANSPORT_ALGORITHM = "jp.openam.saml.xmlenc.xmlEncKeyTransportAlgorithm";
+
     /**
      * Property name for the global default query signature algorithm for RSA keys.
      */

--- a/openam-server-only/src/main/resources/services/famFederationCommon.xml
+++ b/openam-server-only/src/main/resources/services/famFederationCommon.xml
@@ -27,6 +27,7 @@
    $Id: famFederationCommon.xml,v 1.4 2010/01/08 22:41:43 exu Exp $
                                                                                 
    Portions Copyrighted 2015-2016 ForgeRock AS.
+   Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 -->
 
@@ -235,6 +236,21 @@
                     </ChoiceValues>
                     <DefaultValues>
                         <Value>http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512</Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="EncryptionKeyTransportAlgorithm" 
+                    type="single_choice" 
+                    syntax="string" 
+                    i18nKey="a1154"
+                    order="1550"
+                    resourceName="encryptionKeyTransportAlgorithm">
+                    <ChoiceValues>
+                        <ChoiceValue i18nKey="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p">http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</ChoiceValue>
+                        <ChoiceValue i18nKey="http://www.w3.org/2009/xmlenc11#rsa-oaep">http://www.w3.org/2009/xmlenc11#rsa-oaep</ChoiceValue>
+                        <ChoiceValue i18nKey="http://www.w3.org/2001/04/xmlenc#rsa-1_5">http://www.w3.org/2001/04/xmlenc#rsa-1_5</ChoiceValue>
+                    </ChoiceValues>
+                    <DefaultValues>
+                        <Value>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</Value>
                     </DefaultValues>
                 </AttributeSchema>
                 <AttributeSchema name="TransformationAlgorithm" 

--- a/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
+++ b/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
@@ -21,6 +21,7 @@
 # your own identifying information:
 # "Portions Copyrighted [year] [name of copyright owner]"
 #
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 defaults.to.upgrade=com.iplanet.am.version,com.iplanet.am.console.deploymentDescriptor,com.iplanet.am.daemons,\
   com.iplanet.am.buildVersion,com.iplanet.am.buildRevision,com.iplanet.am.buildDate
@@ -37,5 +38,6 @@ upgrade.helper=iPlanetAMLoggingService=org.forgerock.openam.upgrade.helpers.Logg
   iPlanetAMAuthScriptedService=org.forgerock.openam.upgrade.helpers.ScriptedAuthHelper,\
   iPlanetAMAuthDeviceIdMatchService=org.forgerock.openam.upgrade.helpers.ScriptedAuthHelper,\
   AuditService=org.forgerock.openam.upgrade.helpers.AuditUpgradeHelper,\
-  iPlanetAMAuthOpenIdConnectService=org.forgerock.openam.upgrade.helpers.OpenIdConnectAuthModuleServiceHelper
+  iPlanetAMAuthOpenIdConnectService=org.forgerock.openam.upgrade.helpers.OpenIdConnectAuthModuleServiceHelper,\
+  sunFAMFederationCommon=jp.co.osstech.openam.upgrade.helpers.FederationCommonUpgradeHelper
 services.to.delete=iPlanetAMAuthSafeWordService,iPlanetAMAuthUnixService,sunFAMLibertyInteractionService,sunFAMLibertySecurityService,sunAMAuthWSSAuthModuleService,sunFAMSTSService,iPlanetAMAuthDevicePrintModuleService

--- a/openam-upgrade/pom.xml
+++ b/openam-upgrade/pom.xml
@@ -67,6 +67,10 @@
             <groupId>jp.openam</groupId>
             <artifactId>openam-uma</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jp.openam</groupId>
+            <artifactId>openam-federation-library</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/helpers/FederationCommonUpgradeHelper.java
+++ b/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/helpers/FederationCommonUpgradeHelper.java
@@ -1,0 +1,54 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2019 Open Source Solution Technology Corporation
+ */
+package jp.co.osstech.openam.upgrade.helpers;
+
+import static org.forgerock.openam.utils.CollectionUtils.*;
+
+import java.util.Set;
+
+import com.sun.identity.sm.AbstractUpgradeHelper;
+import com.sun.identity.sm.AttributeSchemaImpl;
+import com.sun.identity.xmlenc.EncryptionConstants;
+import org.forgerock.openam.upgrade.UpgradeException;
+
+/**
+ * This upgrade helper is used to add new default values to 
+ * the Common Federation Configuration schema.
+ */
+public class FederationCommonUpgradeHelper extends AbstractUpgradeHelper {
+    
+    private static final String XMLENC_KEY_TRANSPORT_ALGORITHM = "EncryptionKeyTransportAlgorithm";
+
+    public FederationCommonUpgradeHelper() {
+    }
+
+    @Override
+    public AttributeSchemaImpl addNewAttribute(Set<AttributeSchemaImpl> existingAttrs, AttributeSchemaImpl newAttr)
+            throws UpgradeException {
+        // Keep RSA-v1.5 if upgrading from older versions
+        if (XMLENC_KEY_TRANSPORT_ALGORITHM.equals(newAttr.getName())) {
+            updateDefaultValues(newAttr, asSet(EncryptionConstants.ENC_KEY_ENC_METHOD_RSA_1_5));
+        }
+        return newAttr;
+    }
+
+    @Override
+    public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl oldAttr, AttributeSchemaImpl newAttr)
+            throws UpgradeException {
+        return newAttr;
+    }
+    
+}


### PR DESCRIPTION
## Analysis

OpenAM uses only RSA-v1.5 as key transfer algorithm for SAML assertions.

## Solution

Add an option to use RSA-OAEP in `Common Federation Configuration`

## Install/Update

The default value of new option is as follows:

* Initial installation -> RSA-OAEP (including MGF1 with SHA1)
* Upgrade from previous version -> RSA-v1.5
* Upgrade from fixd version -> Keep current value

## Testing

### Test key transfer algorithm with Shibboleth SP

* RSA-OAEP (including MGF1 with SHA1) -> Access OK
* RSA-OAEP -> Access OK
* RSA-v1.5 -> Error (Security policy by Shibboleth SP)

### Upgrade Test

* Initial installation -> RSA-OAEP (including MGF1 with SHA1)
* Upgrade from previous version -> RSA-v1.5
* Upgrade from fixd version -> Keep current value