### PR TITLE
Issue #88 Expired Token remains in CTS

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperConnection.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperConnection.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.cts.impl.query.reaper;
 
@@ -117,7 +118,8 @@ public class ReaperConnection<C extends Closeable> implements ReaperQuery {
     /**
      * Close and null the connection.
      */
-    private void close() {
+    public void close() {
         IOUtils.closeIfNotNull(connection);
+        connection = null;
     }
 }

--- a/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperImpl.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperImpl.java
@@ -12,11 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.cts.impl.query.reaper;
 
 import static org.forgerock.openam.utils.Time.*;
 
+import java.io.IOException;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Iterator;
@@ -102,5 +104,9 @@ public class ReaperImpl<C, F> implements ReaperQuery {
      */
     private boolean isQueryComplete() {
         return !results.hasNext();
+    }
+
+    @Override
+    public void close() throws IOException {
     }
 }

--- a/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperQuery.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/impl/query/reaper/ReaperQuery.java
@@ -12,12 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.cts.impl.query.reaper;
 
 import org.forgerock.openam.cts.exceptions.CoreTokenException;
 import org.forgerock.openam.cts.reaper.CTSReaper;
 
+import java.io.Closeable;
 import java.util.Collection;
 
 /**
@@ -26,7 +28,7 @@ import java.util.Collection;
  *
  * @see CTSReaper
  */
-public interface ReaperQuery {
+public interface ReaperQuery extends Closeable {
     /**
      * Repeated calls will return further results from query.
      *

--- a/openam-core/src/main/java/org/forgerock/openam/cts/reaper/CTSReaper.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/reaper/CTSReaper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.cts.reaper;
 
@@ -25,6 +26,8 @@ import org.forgerock.openam.cts.impl.query.reaper.ReaperQueryFactory;
 import org.forgerock.openam.cts.monitoring.CTSReaperMonitoringStore;
 
 import javax.inject.Inject;
+
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -93,9 +96,7 @@ public class CTSReaper implements Runnable {
         // Latches will track deletion of each page of results
         List<CountDownLatch> latches = new ArrayList<CountDownLatch>();
 
-        ReaperQuery reaperQuery = queryFactory.getQuery();
-
-        try {
+        try (ReaperQuery reaperQuery = queryFactory.getQuery()) {
             long total = 0;
             query.start();
             for (Collection<String> ids = reaperQuery.nextPage(); ids != null; ids = reaperQuery.nextPage()) {
@@ -131,7 +132,7 @@ public class CTSReaper implements Runnable {
             monitoringStore.addReaperRun(query.getStartTime(), query.getTime() + waiting.getTime(), total);
 
             debug("Worker threads Time: {0}ms", Long.toString(waiting.getTime()));
-        } catch (CoreTokenException e) {
+        } catch (CoreTokenException | IOException e) {
             debug.error("CTS Reaper failed", e);
         }
 


### PR DESCRIPTION
## Analysis

The `ReaperConnection` handled by `CTSReaper` closes the LDAP connection when it is determined that there is no entry to be deleted, or when a `CoreTokenException` occurs.
If `ReaperConnection` finds entries to delete and CTS stops in the middle of those deletions, `CTSReaper` exits without `ReaperConnection` closing the LDAP connection.

```
openam-core/src/main/java/org/forgerock/openam/cts/reaper/CTSReaper.java
     98         try {
     99             long total = 0;
    100             query.start();
    101             for (Collection<String> ids = reaperQuery.nextPage(); ids != null; ids = reaperQuery.nextPage()) { 
    102                 // If the thread has been interrupted, exit all processing.
    103                 if (Thread.interrupted()) {
    104                     Thread.currentThread().interrupt();
    105                     debug("Interrupted, returning");
    106                     return;
    107                 }
    108 
    109                 total += ids.size();
    110                 debug("Queried {0} tokens", Long.toString(total));
    111 
    112                 // Latch will track the deletions of the page
    113                 latches.add(tokenDeletion.deleteBatch(ids)); // Stopping CTS here causes DataLayerRuntimeException
    114             }
```

As a result, the next time `CTSReaper` runs, `ReaperConnection` hangs on getting an LDAP connection.

## Solution

Close `ReaperConnection` even if an unexpected exception occurs

## Testing

* Try #88 "Steps to reproduce"