### PR TITLE
Issue #138 scopes supported is not hotswap

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
@@ -701,9 +701,8 @@ public class OAuth2ProviderSettings extends OpenAMSettingsImpl {
      * @throws ServerException If any internal server error occurs.
      */
     public Set<String> getSupportedScopes() throws ServerException {
-//        return supportedScopesWithoutTranslations = getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES,
-//                supportedScopesWithoutTranslations);
-        return getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES, null);
+        return supportedScopesWithoutTranslations = getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES,
+                supportedScopesWithoutTranslations);
     }
 
     /**
@@ -1259,6 +1258,8 @@ public class OAuth2ProviderSettings extends OpenAMSettingsImpl {
                     attributeCache.clear();
                     jwks.clear();
                     loginUrlTemplate = null;
+                    supportedScopesWithoutTranslations = null;
+                    supportedClaimsWithoutTranslations = null;
                 }
             } else {
                 if (logger.messageEnabled()) {

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.oauth2.core;

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
@@ -701,8 +701,9 @@ public class OAuth2ProviderSettings extends OpenAMSettingsImpl {
      * @throws ServerException If any internal server error occurs.
      */
     public Set<String> getSupportedScopes() throws ServerException {
-        return supportedScopesWithoutTranslations = getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES,
-                supportedScopesWithoutTranslations);
+//        return supportedScopesWithoutTranslations = getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES,
+//                supportedScopesWithoutTranslations);
+        return getWithoutTranslations(OAuth2Constants.OAuth2ProviderService.SUPPORTED_SCOPES, null);
     }
 
     /**


### PR DESCRIPTION
## Analysis

Not clearing claims and scopes cache when OAuth provider configuration is completed.

## Solution

Clearing hashset of claims and scopes at the organizationConfigChanged method in OAuth2ProviderSettings class.

## Testing

* Try #138 "Steps to reproduce".
  At that time, Test the supported_claims as well.

## Regression testing

* Try #138 "Steps to reproduce".
  At that time, Test the supported_claims as well.
