### PR TITLE
Issue #45 Authentication process can not continue if local authentication fails in SAML2 authentication

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -34,11 +35,12 @@ define([
     "org/forgerock/commons/ui/common/util/UIUtils",
     "org/forgerock/commons/ui/common/util/URIUtils",
     "org/forgerock/openam/ui/common/util/uri/query",
-    "org/forgerock/openam/ui/user/login/gotoUrl"
+    "org/forgerock/openam/ui/user/login/gotoUrl",
+    "org/forgerock/openam/ui/user/login/tokens/AuthenticationToken"
 
 ], ($, _, AbstractView, AuthNService, BootstrapDialog, Configuration, Constants, CookieHelper, EventManager, Form2js,
     Handlebars, Messages, RESTLoginHelper, RealmHelper, Router, SessionManager, UIUtils,
-    URIUtils, query, gotoUrl) => {
+    URIUtils, query, gotoUrl, AuthenticationToken) => {
 
     function hasSsoRedirectOrPost (goto) {
         let decodedGoto;
@@ -229,7 +231,7 @@ define([
                     // enabled the login button if login failure
                     $(e.currentTarget).prop("disabled", false);
                     // If its not the first stage then render the Login Unavailable view with link back to login screen.
-                    if (Configuration.globalData.auth.currentStage > 1) {
+                    if (Configuration.globalData.auth.currentStage > 1 || AuthenticationToken.had()) {
                         let fragmentParams = URIUtils.getCurrentFragmentQueryString();
                         if (fragmentParams) {
                             fragmentParams = `&${fragmentParams}`;

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/AuthenticationToken.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/AuthenticationToken.jsm
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 /**
@@ -38,9 +39,17 @@ export function set (token) {
 }
 
 export function get () {
-    return CookieHelper.getCookie(cookieName);
+    const cookie = CookieHelper.getCookie(cookieName);
+    if (cookie) {
+        Configuration.globalData.auth.authenticateWithAuthIdCookie = true;
+    }
+    return cookie;
 }
 
 export function remove () {
     return CookieHelper.deleteCookie(cookieName, "/", cookieDomains());
+}
+
+export function had () {
+    return Configuration.globalData.auth.authenticateWithAuthIdCookie;
 }


### PR DESCRIPTION
## Analysis

For example, if a multi-factor authentication chain is configured, an authentication failure screen will be displayed if the second authentication fails.

Because of this specification, `RESTLoginView.js` determines whether the authentication stage is greater than 1 when authentication fails. 
However, this determination does not consider redirect callbacks. If authentication fails after returning from the redirect callback, the authentication stage should be considered 1 or higher.

## Solution

The redirect callback creates an authId cookie before redirecting. This cookie allows the authentication process to continue after returning to OpenAM. Therefore if the authentication process handled the authId cookie, it can be determined that the redirect was returned. 

This fix changes OpenAM to display an authentication failure screen if authentication fails after processing the authId cookie.

## Testing

* Try #45 "Steps to reproduce"