### PR TITLE
Issue #115 Audit Event Handler ignores realm-based log configurations

### DIFF
--- a/openam-audit/openam-audit-configuration/src/main/java/org/forgerock/openam/audit/configuration/AuditServiceConfigurationProviderImpl.java
+++ b/openam-audit/openam-audit-configuration/src/main/java/org/forgerock/openam/audit/configuration/AuditServiceConfigurationProviderImpl.java
@@ -290,7 +290,7 @@ public class AuditServiceConfigurationProviderImpl implements AuditServiceConfig
 
     private Set<String> getRealmNames() {
         try {
-            RealmUtils.getRealmNames(getAdminToken());
+            return RealmUtils.getRealmNames(getAdminToken());
         } catch (SMSException e) {
             debug.error("An error occurred while trying to retrieve the list of realms", e);
         }


### PR DESCRIPTION
## Analysis
The realm name cannot be retrieved because the "getRealmNames" method of "AuditServiceConfigurationProviderImpl.java" always returns an empty set. As a result, the realm can't receive notifications and the realm-based log configurations are not applied.

## Solution
cherry picked from commit f96dd27c67910ef1d8eff763c7f7f209966c39ef.

## Testing
 - Try [#115](https://github.com/openam-jp/openam/issues/115) "Steps to reproduce".