### PR TITLE
Issue #89 Policy based access control for SAML 2.0 IdP (new feature)

### DIFF
--- a/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/conditions/environment/AMIdentityMembershipCondition.java
+++ b/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/conditions/environment/AMIdentityMembershipCondition.java
@@ -15,6 +15,7 @@
  */
 /*
  * Portions Copyright 2011-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.entitlement.conditions.environment;
@@ -43,8 +44,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.sun.identity.entitlement.EntitlementException.*;
+import com.sun.identity.entitlement.opensso.SubjectUtils;
 import static org.forgerock.openam.entitlement.conditions.environment.ConditionConstants.AM_IDENTITY_NAME;
-import static org.forgerock.openam.entitlement.conditions.environment.ConditionConstants.INVOCATOR_PRINCIPAL_UUID;
 
 /**
  * An implementation of an {@link com.sun.identity.entitlement.EntitlementCondition} that will check whether the
@@ -106,18 +107,16 @@ public class AMIdentityMembershipCondition extends EntitlementConditionAdaptor {
     public ConditionDecision evaluate(String realm, Subject subject, String resourceName, Map<String, Set<String>> env)
             throws EntitlementException {
 
+        String subjectPrincipal = SubjectUtils.getPrincipalId(subject);
         if (debug.messageEnabled()) {
-            debug.message("At AMIdentityMembershipCondition.getConditionDecision(): entering, names:" + amIdentityName);
-            debug.message("At AMIdentityMembershipCondition.getConditionDecision(): environment.invocatorPrincipalUud:"
-                    + env.get(INVOCATOR_PRINCIPAL_UUID));
+            debug.message("At AMIdentityMembershipCondition.evaluate(): entering, names:" + amIdentityName);
+            debug.message("At AMIdentityMembershipCondition.evaluate(): subjectPrincipal:" + subjectPrincipal);
         }
         boolean isMember = false;
-        Set<String> invocatorUuidSet = env.get(INVOCATOR_PRINCIPAL_UUID);
-        if (invocatorUuidSet != null && !invocatorUuidSet.isEmpty()) {
-            String invocatorUuid = invocatorUuidSet.iterator().next();
-            isMember = isMember(invocatorUuid);
+        if (subjectPrincipal != null && !subjectPrincipal.isEmpty()) {
+            isMember = isMember(subjectPrincipal);
         } else {
-            debug.message("At AMIdentityMembershipCondition.getConditionDecision(): invocatorUuidSet is null or empty");
+            debug.message("At AMIdentityMembershipCondition.evaluate(): subjectPrincipal is null or empty");
         }
         return new ConditionDecision(isMember, Collections.<String, Set<String>>emptyMap());
     }

--- a/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/conditions/environment/ConditionConstants.java
+++ b/openam-entitlements/src/main/java/org/forgerock/openam/entitlement/conditions/environment/ConditionConstants.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.entitlement.conditions.environment;
 
@@ -145,14 +146,6 @@ public final class ConditionConstants {
      * option is on if the string value is equal to {@code true}.
      */
     public static final String TERMINATE_SESSION = "TerminateSession";
-
-    /**
-     * Key that is passed in the <code>env</code> parameter while invoking {@code getConditionDecision} method of an
-     * {@code AMIdentityMembershipCondition}. The value specifies the uuid(s) for which the policy would apply. The
-     * value should be a {@code Set}. Each element of the {@code Set} should be a String, the uuid of the
-     * {@code AMIdentity} object.
-     */
-    public static final String INVOCATOR_PRINCIPAL_UUID = "invocatorPrincipalUuid";
 
     /**
      * <p>Key that is used in {@code SimpleTimeCondition} to define the beginning of time range during which a policy

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/AMIdentityMembershipConditionTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/conditions/environment/AMIdentityMembershipConditionTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.entitlement.conditions.environment;
@@ -23,7 +24,9 @@ import com.sun.identity.entitlement.EntitlementException;
 import com.sun.identity.idm.AMIdentity;
 import com.sun.identity.idm.IdRepoException;
 import com.sun.identity.idm.IdType;
+import com.sun.identity.rest.AuthSPrincipal;
 import com.sun.identity.shared.debug.Debug;
+import java.security.Principal;
 import org.forgerock.openam.core.CoreWrapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -36,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.openam.entitlement.conditions.environment.ConditionConstants.INVOCATOR_PRINCIPAL_UUID;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -114,9 +116,9 @@ public class AMIdentityMembershipConditionTest {
         Subject subject = new Subject();
         String resourceName = "RESOURCE_NAME";
         Map<String, Set<String>> env = new HashMap<String, Set<String>>();
-        Set<String> invocatorUuids = new HashSet<String>();
+        Set<Principal> principals = new HashSet<>();
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, invocatorUuids);
+        subject.getPrincipals().addAll(principals);
         condition.setState("{\"amIdentityName\": [\"IDENTITY_ONE\", \"IDENTITY_TWO\"]}");
 
         //When
@@ -136,7 +138,6 @@ public class AMIdentityMembershipConditionTest {
         String resourceName = "RESOURCE_NAME";
         Map<String, Set<String>> env = new HashMap<String, Set<String>>();
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.<String>singleton(null));
         condition.setState("{\"amIdentityName\": [\"IDENTITY_ONE\", \"IDENTITY_TWO\"]}");
 
         //When
@@ -156,7 +157,7 @@ public class AMIdentityMembershipConditionTest {
         String resourceName = "RESOURCE_NAME";
         Map<String, Set<String>> env = new HashMap<String, Set<String>>();
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
 
         //When
         ConditionDecision decision = condition.evaluate(realm, subject, resourceName, env);
@@ -176,7 +177,7 @@ public class AMIdentityMembershipConditionTest {
         String resourceName = "RESOURCE_NAME";
         Map<String, Set<String>> env = new HashMap<String, Set<String>>();
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY_ONE\", \"IDENTITY_TWO\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(null);
@@ -200,7 +201,7 @@ public class AMIdentityMembershipConditionTest {
         Map<String, Set<String>> env = new HashMap<String, Set<String>>();
         AMIdentity invocatorIdentity = mock(AMIdentity.class);
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);
@@ -226,7 +227,7 @@ public class AMIdentityMembershipConditionTest {
         AMIdentity invocatorIdentity = mock(AMIdentity.class);
         AMIdentity identity = invocatorIdentity;
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);
@@ -254,7 +255,7 @@ public class AMIdentityMembershipConditionTest {
         IdType invocatorIdType = mock(IdType.class);
         IdType identityIdType = mock(IdType.class);
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);
@@ -285,7 +286,7 @@ public class AMIdentityMembershipConditionTest {
         IdType invocatorIdType = mock(IdType.class);
         IdType identityIdType = mock(IdType.class);
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);
@@ -316,7 +317,7 @@ public class AMIdentityMembershipConditionTest {
         IdType invocatorIdType = mock(IdType.class);
         IdType identityIdType = mock(IdType.class);
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);
@@ -348,7 +349,7 @@ public class AMIdentityMembershipConditionTest {
         IdType invocatorIdType = mock(IdType.class);
         IdType identityIdType = mock(IdType.class);
 
-        env.put(INVOCATOR_PRINCIPAL_UUID, Collections.singleton("INVOCATOR_UUID"));
+        subject.getPrincipals().add(new AuthSPrincipal("INVOCATOR_UUID"));
         condition.setState("{\"amIdentityName\": [\"IDENTITY\"]}");
 
         given(coreWrapper.getIdentity(adminToken, "INVOCATOR_UUID")).willReturn(invocatorIdentity);

--- a/openam-federation/openam-federation-library/pom.xml
+++ b/openam-federation/openam-federation-library/pom.xml
@@ -152,6 +152,16 @@
     </build>
 
     <dependencies>
+         <dependency>
+            <groupId>jp.openam</groupId>
+            <artifactId>openam-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jp.openam</groupId>
+            <artifactId>openam-entitlements</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-guice-core</artifactId>

--- a/openam-federation/openam-federation-library/src/main/java/jp/co/osstech/oam/saml2/plugins/PolicyCheckIDPAdapter.java
+++ b/openam-federation/openam-federation-library/src/main/java/jp/co/osstech/oam/saml2/plugins/PolicyCheckIDPAdapter.java
@@ -34,7 +34,7 @@ import com.sun.identity.entitlement.EntitlementException;
 import com.sun.identity.entitlement.Evaluator;
 import com.sun.identity.entitlement.opensso.SubjectUtils;
 import com.sun.identity.federation.common.FSUtils;
-import com.sun.identity.policy.interfaces.Condition;
+import org.forgerock.openam.entitlement.conditions.environment.ConditionConstants;
 import com.sun.identity.saml.common.SAMLUtils;
 import com.sun.identity.saml2.plugins.SAML2IdentityProviderAdapter;
 import com.sun.identity.saml2.common.SAML2Constants;
@@ -52,7 +52,6 @@ import com.sun.identity.shared.encode.URLEncDec;
 import com.sun.identity.sm.DNMapper;
 import java.io.IOException;
 import java.security.AccessController;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -185,14 +184,14 @@ public class PolicyCheckIDPAdapter implements SAML2IdentityProviderAdapter {
                 String paramName = null;
                 String realmQualifiedData = null;
                 
-                advice = advices.get(Condition.AUTH_LEVEL_CONDITION_ADVICE);
+                advice = advices.get(ConditionConstants.AUTH_LEVEL_CONDITION_ADVICE);
                 if (advice != null && !advice.isEmpty()) {
                     paramName = ISAuthConstants.AUTH_LEVEL_PARAM;
                     realmQualifiedData = advice.iterator().next();
                 }
                 
                 if (paramName == null) {
-                    advice = advices.get(Condition.AUTH_SCHEME_CONDITION_ADVICE);
+                    advice = advices.get(ConditionConstants.AUTH_SCHEME_CONDITION_ADVICE);
                     if (advice != null && !advice.isEmpty()) {
                         paramName = ISAuthConstants.MODULE_PARAM;
                         realmQualifiedData = advice.iterator().next();
@@ -200,7 +199,7 @@ public class PolicyCheckIDPAdapter implements SAML2IdentityProviderAdapter {
                 }
 
                 if (paramName == null) {
-                    advice = advices.get(Condition.AUTHENTICATE_TO_SERVICE_CONDITION_ADVICE);
+                    advice = advices.get(ConditionConstants.AUTHENTICATE_TO_SERVICE_CONDITION_ADVICE);
                     if (advice != null && !advice.isEmpty()) {
                         paramName = ISAuthConstants.SERVICE_PARAM;
                         realmQualifiedData = advice.iterator().next();

--- a/openam-federation/openam-federation-library/src/main/java/jp/co/osstech/oam/saml2/plugins/PolicyCheckIDPAdapter.java
+++ b/openam-federation/openam-federation-library/src/main/java/jp/co/osstech/oam/saml2/plugins/PolicyCheckIDPAdapter.java
@@ -1,0 +1,339 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019 Open Source Solution Technology Corporation
+ * All Rights Reserved.
+ *
+ * The contents of this file are subject to the terms
+ * of the Common Development and Distribution License
+ * (the License). You may not use this file except in
+ * compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://forgerock.org/license/CDDLv1.0.html 
+ * See the License for the specific language governing
+ * permission and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL
+ * Header Notice in each file and include the License file
+ * at http://forgerock.org/license/CDDLv1.0.html 
+ * If applicable, add the following below the CDDL Header,
+ * with the fields enclosed by brackets [] replaced by
+ * your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ */
+
+package jp.co.osstech.oam.saml2.plugins;
+
+import com.iplanet.sso.SSOToken;
+import com.sun.identity.authentication.util.AMAuthUtils;
+import com.sun.identity.authentication.util.ISAuthConstants;
+import com.sun.identity.entitlement.Entitlement;
+import com.sun.identity.entitlement.EntitlementException;
+import com.sun.identity.entitlement.Evaluator;
+import com.sun.identity.entitlement.opensso.SubjectUtils;
+import com.sun.identity.federation.common.FSUtils;
+import com.sun.identity.policy.interfaces.Condition;
+import com.sun.identity.saml.common.SAMLUtils;
+import com.sun.identity.saml2.plugins.SAML2IdentityProviderAdapter;
+import com.sun.identity.saml2.common.SAML2Constants;
+import com.sun.identity.saml2.common.SAML2Exception;
+import com.sun.identity.saml2.common.SAML2Utils;
+import com.sun.identity.saml2.profile.IDPCache;
+import com.sun.identity.saml2.profile.IDPSSOUtil;
+import com.sun.identity.saml2.profile.IDPSession;
+import com.sun.identity.saml2.protocol.AuthnRequest;
+import com.sun.identity.saml2.protocol.Response;
+import com.sun.identity.security.AdminTokenAction;
+import com.sun.identity.shared.Constants;
+import com.sun.identity.shared.configuration.SystemPropertiesManager;
+import com.sun.identity.shared.encode.URLEncDec;
+import com.sun.identity.sm.DNMapper;
+import java.io.IOException;
+import java.security.AccessController;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.ServletException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.forgerock.openam.utils.StringUtils;
+
+/**
+ * This class <code>PolicyCheckIDPAdapter</code> implements a SAML2 Identity Provider Adapter.
+ */
+public class PolicyCheckIDPAdapter implements SAML2IdentityProviderAdapter {
+    
+    private static final String INDEX = "index";
+    private static final String ACS_URL = "acsURL";
+    private static final String SP_ENTITY_ID = "spEntityID";
+    private static final String IDP_ENTITY_ID = "idpEntityID";
+    private static final String BINDING = "binding";
+    private static final String POLICY_SET_NAME = "SAML2ProviderService";
+    private static final String ACTION_NAME = "IssueAssertion";
+    public static final String REALM_DN = "am.policy.realmDN";
+    
+    /**
+     * Default Constructor.
+     */
+    public PolicyCheckIDPAdapter() {
+    }
+
+    /**
+     * Default implementation, takes no action.
+     */
+    @Override
+    public void initialize(String hostedEntityID, String realm) {
+        // Do nothing
+    }
+
+    /**
+     * Default implementation, takes no action and returns false (no interruption to processing).
+     * @throws com.sun.identity.saml2.common.SAML2Exception
+     */
+    @Override
+    public boolean preSingleSignOn(
+            String hostedEntityID,
+            String realm,
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthnRequest authnRequest,
+            String reqID) throws SAML2Exception {
+        return false;
+    }
+
+    /**
+     * Default implementation, takes no action and returns false (no interruption to processing).
+     * @throws com.sun.identity.saml2.common.SAML2Exception
+     */
+    @Override
+    public boolean preAuthentication(
+            String hostedEntityID,
+            String realm,
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthnRequest authnRequest,
+            Object session,
+            String reqID,
+            String relayState) throws SAML2Exception {
+        return false;
+    }
+
+    /**
+     * Check policy and if necessary redirect for additional authentication.
+     * @throws com.sun.identity.saml2.common.SAML2Exception
+     */
+    @Override
+    public boolean preSendResponse(
+            AuthnRequest authnRequest,
+            String hostProviderID,
+            String realm,
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object session,
+            String reqID,
+            String relayState) throws SAML2Exception {
+        
+        final String classMethod = "preSendResponse:";
+        final SSOToken token = (SSOToken)session;
+        Map<String, Set<String>> env = new HashMap<>();
+        
+        if (realm == null || realm.length() == 0) {
+            SAML2Utils.debug.error("{} realm was null or empty", classMethod);
+            SAMLUtils.sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    "errorCode0", "Failed to evaluate provider policy");
+            return true;
+        }
+        Set<String> set = new HashSet<>();
+        set.add(DNMapper.orgNameToDN(realm));
+        env.put(REALM_DN, set);
+        
+        final String spEntityID = authnRequest.getIssuer().getValue();
+        if (spEntityID == null) {
+            SAML2Utils.debug.error("{} Failed to get spEntityID from authnRequest", classMethod);
+            SAMLUtils.sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    "errorCode1", "Failed to evaluate policy");
+            return true;
+        }
+        String resourceString = String.format("%s=%s&%s=%s", IDP_ENTITY_ID, hostProviderID, SP_ENTITY_ID, spEntityID);
+
+        List<Entitlement> entitlements;
+        SSOToken adminSSOToken = (SSOToken) AccessController.doPrivileged(AdminTokenAction.getInstance());
+            
+        try {
+            Evaluator evaluator = new Evaluator(SubjectUtils.createSubject(adminSSOToken), POLICY_SET_NAME);
+            entitlements = evaluator.evaluate(realm, SubjectUtils.createSubject(token), resourceString, env, false);
+        } catch (EntitlementException eex) {
+            SAML2Utils.debug.error("{} Failed to evaluate policy {}", classMethod, eex.getMessage());
+            SAMLUtils.sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                    "errorCode2", "Failed to evaluate policy");
+            return true;
+        }       
+        
+        Entitlement result = entitlements.get(0);
+        Boolean allowed = result.getActionValue(ACTION_NAME);
+        
+        if (allowed == null || !allowed) {
+            if (result.hasAdvice()) {
+                Map <String, Set<String>> advices = result.getAdvices();
+                Set<String> advice;           
+                String paramName = null;
+                String realmQualifiedData = null;
+                
+                advice = advices.get(Condition.AUTH_LEVEL_CONDITION_ADVICE);
+                if (advice != null && !advice.isEmpty()) {
+                    paramName = ISAuthConstants.AUTH_LEVEL_PARAM;
+                    realmQualifiedData = advice.iterator().next();
+                }
+                
+                if (paramName == null) {
+                    advice = advices.get(Condition.AUTH_SCHEME_CONDITION_ADVICE);
+                    if (advice != null && !advice.isEmpty()) {
+                        paramName = ISAuthConstants.MODULE_PARAM;
+                        realmQualifiedData = advice.iterator().next();
+                    }
+                }
+
+                if (paramName == null) {
+                    advice = advices.get(Condition.AUTHENTICATE_TO_SERVICE_CONDITION_ADVICE);
+                    if (advice != null && !advice.isEmpty()) {
+                        paramName = ISAuthConstants.SERVICE_PARAM;
+                        realmQualifiedData = advice.iterator().next();
+                    }
+                }
+                
+                String nvPair = null;
+                if (paramName != null && realmQualifiedData != null) {
+                    String adviceValue = AMAuthUtils.getDataFromRealmQualifiedData(realmQualifiedData);
+                    nvPair = String.format("%s=%s", paramName, adviceValue);
+                }
+
+                if (nvPair != null) {
+                    try {
+                        redirectToAuth(request, response, authnRequest, realm, hostProviderID, reqID, nvPair);
+                        String sessionIndex = IDPSSOUtil.getSessionIndex(token);
+                        if (sessionIndex != null && sessionIndex.length() != 0) {
+                            IDPSession oldIDPSession = IDPCache.idpSessionsByIndices.get(sessionIndex);
+                            if (oldIDPSession != null) {
+                                IDPCache.oldIDPSessionCache.put(reqID, oldIDPSession);
+                            } else {
+                                SAML2Utils.debug.error(classMethod + "The old SAML2 session was not found in the idp session " +
+                                    "by indices cache");
+                            }
+                        }
+                        IDPCache.isSessionUpgradeCache.add(reqID);
+                    } catch (SAML2Exception | IOException | ServletException ex) {
+                        SAML2Utils.debug.error("{} Failed to redirect to Auth {}", classMethod, ex.getMessage());
+                            SAMLUtils.sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                                    "errorCode3", "Failed to evaluate policy");
+                    }
+                    return true;
+                }
+            }
+
+            SAML2Utils.debug.warning("{} Policy denied the access", classMethod);
+            SAMLUtils.sendError(request, response, HttpServletResponse.SC_FORBIDDEN,
+                "errorCode4", "SAML endpoint protected by policy");
+            return true;
+        }
+        return false;
+    }
+    
+    private static void redirectToAuth(HttpServletRequest request,
+            HttpServletResponse response, AuthnRequest authnRequest, String realm,
+            String hostProviderID, String reqID, String nvPair) 
+            throws SAML2Exception, IOException, ServletException {
+        
+        final String classMethod = "redirectToAuth:";
+        String rootUrl;
+        
+        String authService = IDPSSOUtil.getAuthenticationServiceURL(realm, hostProviderID, request);
+        rootUrl = request.getScheme() + "://" + request.getServerName() 
+                + ":" + request.getServerPort() + request.getContextPath();
+        boolean forward;
+        StringBuffer authURL;
+
+        if (FSUtils.isSameContainer(request, authService)) { // Forward
+            forward = true;
+            String relativePath = authService.substring(rootUrl.length());
+            authURL = new StringBuffer(relativePath).append("&forward=true");
+        } else { // Redirect
+            forward = false;
+            authURL = new StringBuffer(authService);
+        }
+        
+        String spEntityID = authnRequest.getIssuer().getValue();
+
+        if (authURL.indexOf("?") == -1) {
+            authURL.append("?");
+        } else {
+            authURL.append("&");
+        }
+        authURL.append(SAML2Constants.SPENTITYID).append("=").append(URLEncDec.encode(spEntityID));
+        authURL.append("&").append(nvPair).append("&ForceAuth=true&goto=");
+
+        StringBuffer gotoURL;
+        if (forward) {  // Forward needs a relative URL
+            gotoURL = new StringBuffer(request.getRequestURI().substring(request.getContextPath().length()));
+        } else {  // Redirect needs an absolute URL
+            String rpUrl = IDPSSOUtil.getAttributeValueFromIDPSSOConfig(realm, hostProviderID, SAML2Constants.RP_URL);
+            if (StringUtils.isNotEmpty(rpUrl)) {
+                gotoURL = new StringBuffer(rpUrl);
+                gotoURL.append(request.getRequestURI().substring(request.getContextPath().length()));
+            } else {
+                gotoURL = request.getRequestURL();
+            }
+        }
+
+        /** Just in case that the original authnRequest get lost.
+         * 
+         *  Adding these extra parameters will ensure that we can send back SAML error response to the SP even when the
+         *  originally received AuthnRequest gets lost.
+         */
+
+        gotoURL.append("?ReqID=").append(reqID).append('&')
+                .append(INDEX).append('=').append(authnRequest.getAssertionConsumerServiceIndex()).append('&')
+                .append(ACS_URL).append('=').append(URLEncDec.encode(authnRequest.getAssertionConsumerServiceURL())).append('&')
+                .append(SP_ENTITY_ID).append('=').append(URLEncDec.encode(authnRequest.getIssuer().getValue())).append('&')
+                .append(BINDING).append('=').append(URLEncDec.encode(authnRequest.getProtocolBinding()));
+
+        authURL.append(URLEncDec.encode(gotoURL.toString()));
+        SAML2Utils.debug.message("{} New URL for authentication: {}", classMethod, authURL.toString());
+
+        if (forward) { // In the same container 
+            authURL.append('&').append(SystemPropertiesManager.get(Constants.AM_AUTH_COOKIE_NAME, "AMAuthCookie"));
+            authURL.append('=');
+
+            SAML2Utils.debug.message("{} Forward to ", classMethod, authURL.toString());
+            request.setAttribute(Constants.FORWARD_PARAM, Constants.FORWARD_YES_VALUE);
+            request.getRequestDispatcher(authURL.toString()).forward(request, response);        
+        } else {  // Seperate container
+            response.sendRedirect(authURL.toString());
+        }
+    }
+    
+    /**
+     * Default implementation, takes no action.
+     * @throws com.sun.identity.saml2.common.SAML2Exception
+     */
+    @Override
+    public void preSendFailureResponse(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String faultCode,
+            String faultDetail) throws SAML2Exception {
+        // Do nothing
+    }
+
+    @Override
+    public void preSignResponse(AuthnRequest authnRequest, Response res, String hostProviderID, String realm,
+        HttpServletRequest request, Object session, String relayState) throws SAML2Exception {
+        // Do nothing
+    }
+
+}

--- a/openam-server-only/src/main/resources/services/entitlement.xml
+++ b/openam-server-only/src/main/resources/services/entitlement.xml
@@ -27,6 +27,7 @@
    $Id: entitlement.xml,v 1.9 2010/01/07 00:19:12 veiming Exp $
 
    Portions copyright 2011-2016 ForgeRock AS.
+   Portions Copyrighted 2019 Open Source Solution Technology Corporation.
 -->
 
 <!DOCTYPE ServicesConfiguration
@@ -345,6 +346,26 @@
                         <AttributeValuePair>
                             <Attribute name="resourceComparator" />
                             <Value>com.sun.identity.entitlement.URLResourceName</Value>
+                        </AttributeValuePair>
+                    </SubConfiguration>
+                    <SubConfiguration name="AuthProviderService"
+                        id="applicationType">
+                        <AttributeValuePair>
+                            <Attribute name="actions" />
+                            <Value>IssueAssertion=true</Value>
+                            <Value>IssueToken=true</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="searchIndexImpl" />
+                            <Value>org.forgerock.openam.entitlement.indextree.TreeSearchIndex</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="saveIndexImpl" />
+                            <Value>org.forgerock.openam.entitlement.indextree.TreeSaveIndex</Value>
+                        </AttributeValuePair>
+                        <AttributeValuePair>
+                            <Attribute name="resourceComparator" />
+                            <Value>com.sun.identity.entitlement.RegExResourceName</Value>
                         </AttributeValuePair>
                     </SubConfiguration>
                     <SubConfiguration name="crestPolicyService" id="applicationType">

--- a/openam-ui/openam-ui-ria/src/main/js/config/routes/admin/RealmsRoutes.js
+++ b/openam-ui/openam-ui-ria/src/main/js/config/routes/admin/RealmsRoutes.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation.
  */
 
 define(function () {
@@ -185,6 +186,15 @@ define(function () {
                 page: "org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditPolicySetView",
                 url: scopedByRealm("authorization-policySets/new"),
                 pattern: "realms/?/authorization-policySets/new",
+                role: "ui-realm-admin",
+                navGroup: "admin",
+                forceUpdate: true
+            },
+            "realmsProviderPolicySetNew": {
+                view: "org/forgerock/openam/ui/admin/views/realms/RealmTreeNavigationView",
+                page: "org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditProviderPolicySetView",
+                url: scopedByRealm("authorization-provider-policySets/new"),
+                pattern: "realms/?/authorization-provider-policySets/new",
                 role: "ui-realm-admin",
                 navGroup: "admin",
                 forceUpdate: true

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditProviderPolicySetView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditProviderPolicySetView.js
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright (c) 2019 Open Source Solution Technology Corporation
+ *
+ */
+
+define("org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditProviderPolicySetView", [
+    "org/forgerock/openam/ui/admin/views/realms/authorization/policySets/EditPolicySetView"
+], function (EditPolicySetView) {
+    return EditPolicySetView.extend({
+        APPLICATION_TYPE: "AuthProviderService"
+    });
+});

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policySets/PolicySetsView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policySets/PolicySetsView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation.
  */
 
 
@@ -44,6 +45,7 @@ define([
         ],
         events: {
             "click [data-add-entity]":      "addNewPolicySet",
+            "click [data-add-pp-entity]": "addNewProviderPolicySet",
             "click [data-import-policies]": "startImportPolicies",
             "click [data-export-policies]": "exportPolicies",
             "click [data-add-resource]":    "addResource",
@@ -219,6 +221,13 @@ define([
 
         addNewPolicySet () {
             Router.routeTo(Router.configuration.routes.realmsPolicySetNew, {
+                args: [encodeURIComponent(this.realmPath)],
+                trigger: true
+            });
+        },
+
+        addNewProviderPolicySet () {
+            Router.routeTo(Router.configuration.routes.realmsProviderPolicySetNew, {
                 args: [encodeURIComponent(this.realmPath)],
                 trigger: true
             });

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
@@ -717,6 +717,7 @@
                 "authentication-chains": "Authentication - Chains",
                 "authentication-modules": "Authentication - Modules",
                 "authorization-policySets": "Authorization - Policy Sets",
+                "authorization-provider-policySets": "Authorization - Provider Policy Sets",
                 "authorization-resourceTypes": "Authorization - Resource Types",
                 "general": "General",
                 "security": "Security",
@@ -1074,6 +1075,7 @@
                 },
                 "list": {
                     "addNew": "New Policy Set",
+                    "addNewPP": "New Provider Policy Set",
                     "description": "Define sets of policies for protecting web sites, web applications, or other resources.",
                     "importPolicySets": "Import Policy Sets",
                     "exportPolicySets": "Export Policy Sets",

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
@@ -717,6 +717,7 @@
                 "authentication-chains": "認証 - 認証連鎖",
                 "authentication-modules": "認証 - モジュール",
                 "authorization-policySets": "認可 - ポリシーセット",
+                "authorization-provider-policySets": "認可 - プロバイダー ポリシーセット",
                 "authorization-resourceTypes": "認可 - リソースタイプ",
                 "general": "一般",
                 "security": "セキュリティ",
@@ -1074,6 +1075,7 @@
                 },
                 "list": {
                     "addNew": "新規ポリシーセット",
+                    "addNewPP": "新規プロバイダポリシーセット",
                     "description": "Web サイト、 Web アプリケーション、またはその他のリソースを保護するためのポリシーのセットを定義します。",
                     "importPolicySets": "ポリシーのインポート",
                     "exportPolicySets": "ポリシーのエクスポート",

--- a/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authorization/policySets/PolicySetsToolbarTemplate.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authorization/policySets/PolicySetsToolbarTemplate.html
@@ -2,6 +2,10 @@
     <i class="fa fa-plus"></i> {{t "console.authorization.policySets.list.addNew"}}
 </button>
 
+<a role="button" class="btn btn-default pull-left" data-add-pp-entity>
+    <i class="fa fa-plus"></i> {{t "console.authorization.policySets.list.addNewPP"}}
+</a>
+
 <a role="button" class="btn btn-default pull-right" data-export-policies>
     <i class="fa fa-upload"></i> {{t "console.authorization.policySets.list.exportPolicySets"}}
 </a>


### PR DESCRIPTION
## Analysis
See the description section of the Issue #89.
## Solution

See the solution mentioned in the Issue #89.

This feature is made up of three parts described below:

1. An implementation of `SAML2IdentityProviderAdapter` interface.  Its `preSendResponse` method checks user/session properties against defined policies.

2. A definition of service configuration called `AuthProviderService`.  It is used for creating access policies .

3. Additional parameters used for policy evaluation.  Some env conditions, namely `LDAP filter condition` and `Membership condition` require realm or subject parameters.

## Install/Update

A simple configuration guide is attached with this request.

## Compatibility

None.

## Performance

Performance might be affected if complicated access policies need to be applied.

## I18N

None.

## Testing

- Set up an IdP and an SP.
- Set up the adapter and define access policies (resource, subject conditions, env conditions).
- Request an assertion from the SP.

Depending on the user/session properties, the request is:

- denied or
- accepted and an assertion is issued or
- processed further and session upgrade is performed.

## Regression testing

None.
