### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/openam-core-rest/pom.xml
+++ b/openam-core-rest/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2015 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -60,6 +61,10 @@
             <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/UnsupportedResponse.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/UnsupportedResponse.java
@@ -12,6 +12,8 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * 
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.openam.core.rest.session;
@@ -209,6 +211,10 @@ final class UnsupportedResponse implements HttpServletResponse {
 
     @Override
     public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+    @Override
+    public void setContentLengthLong(long len) {
         throw new UnsupportedOperationException();
     }
 }

--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -23,6 +23,7 @@
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -397,6 +398,11 @@
             <artifactId>forgerock-guice-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteHttpServletRequest.java
+++ b/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteHttpServletRequest.java
@@ -21,6 +21,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.openam.authentication.service.protocol;
@@ -43,6 +44,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.Part;
+import javax.servlet.http.HttpUpgradeHandler;
 
 /**
  * This class encapsulates a HttpServletRequest extending from RemoteServletRequest.
@@ -446,6 +448,19 @@ public class RemoteHttpServletRequest extends RemoteServletRequest implements Ht
     @Override
     public Part getPart(String name) throws IOException, ServletException {
          return this._getHttpServletRequest() != null ? this._getHttpServletRequest().getPart(name) : null;
+    }
+
+    @Override
+    public String changeSessionId(){
+         return this._getHttpServletRequest() != null ? this._getHttpServletRequest().changeSessionId() : null;
+    }
+    @Override
+    public long getContentLengthLong(){
+         return this._getHttpServletRequest() != null ? this._getHttpServletRequest().getContentLengthLong() : -1L;
+    }
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException{
+         return this._getHttpServletRequest() != null ? this._getHttpServletRequest().upgrade(handlerClass) : null;
     }
 
 }

--- a/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteServletRequest.java
+++ b/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteServletRequest.java
@@ -21,6 +21,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.openam.authentication.service.protocol;
@@ -587,5 +588,10 @@ public class RemoteServletRequest implements ServletRequest, Serializable {
                 .append("Remote port      : ").append(remotePort);
 
         return buffer.toString();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+	    return request != null ? this.request.getContentLengthLong() : (long)contentLength;
     }
 }

--- a/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteServletResponse.java
+++ b/openam-core/src/main/java/org/forgerock/openam/authentication/service/protocol/RemoteServletResponse.java
@@ -21,6 +21,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.openam.authentication.service.protocol;
@@ -263,5 +264,12 @@ public class RemoteServletResponse implements ServletResponse, Serializable {
      */
     public Locale getLocale() {
 	    return response != null ? this.response.getLocale() : locale;
+    }
+
+    @Override
+    public void setContentLengthLong(long len){
+        if( response != null ){
+            response.setContentLengthLong(len);
+        }
     }
 }

--- a/openam-federation/OpenFM/pom.xml
+++ b/openam-federation/OpenFM/pom.xml
@@ -23,6 +23,7 @@
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -179,6 +180,10 @@
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-oauth2/pom.xml
+++ b/openam-oauth2/pom.xml
@@ -24,6 +24,7 @@
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -203,6 +204,10 @@
         <dependency>
             <groupId>javassist</groupId>
             <artifactId>javassist</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 

--- a/openam-push-notification/pom.xml
+++ b/openam-push-notification/pom.xml
@@ -14,6 +14,7 @@
   ~
   ~ Copyright 2016 ForgeRock AS.
   ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -44,7 +45,6 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sns</artifactId>
-            <version>1.10.72</version>
         </dependency>
         <dependency>
             <groupId>jp.openam.commons</groupId>

--- a/openam-radius/pom.xml
+++ b/openam-radius/pom.xml
@@ -23,6 +23,7 @@
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
        <dependency>
            <groupId>ch.qos.logback</groupId>
            <artifactId>logback-classic</artifactId>
-           <version>${logback.version}</version>
            <scope>test</scope>
        </dependency>
    </dependencies>    

--- a/openam-samples/custom-authentication-module/pom.xml
+++ b/openam-samples/custom-authentication-module/pom.xml
@@ -21,6 +21,7 @@
    "Portions Copyrighted [year] [name of copyright owner]"
 
    Portions Copyrighted 2019 Open Source Solution Technology Corporation
+   Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -50,8 +51,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/openam-slf4j/pom.xml
+++ b/openam-slf4j/pom.xml
@@ -13,6 +13,7 @@
     *
     * Copyright 2013-2016 ForgeRock AS.
     * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+    * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -31,7 +32,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>jp.openam</groupId>

--- a/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
+++ b/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
@@ -15,6 +15,7 @@
  *
  * Copyright 2013-2016 ForgeRock AS.
  * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -45,10 +46,6 @@
         </pluginManagement>
     </build>
 
-    <properties>
-        <cxf.version>2.7.18</cxf.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jp.openam</groupId>
@@ -73,7 +70,6 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>${cxf.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.geronimo.genesis</groupId>
@@ -84,32 +80,26 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-bindings-soap</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-policy</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf.services.sts</groupId>
             <artifactId>cxf-services-sts-core</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,6 @@
 
             <!-- External project dependencies -->
 
-
             <!-- Mozilla Rhino Javascript engine -->
 
             <!-- Groovy scripting support -->
@@ -966,54 +965,6 @@
             <!-- Groovy JSON parsing support -->
 
             <!-- Override dependency for ESAPI -->
-
-
-
-
-
-
-            <!-- TODO j2ee -->
-
-
-
-
-
-
-
-
-
-            <!-- TODO jmx -->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
             <!-- OpenDJ API -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
 * Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 *
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -128,58 +129,15 @@
 
         <javadoc-utils.version>1.0.0</javadoc-utils.version>
         <ant.contrib.version>1.0b3</ant.contrib.version>
-        <guice.version>3.0</guice.version>
-        <restlet.version>2.3.4</restlet.version>
-        <powermock.version>1.5</powermock.version>
-        <jackson.version>2.9.7</jackson.version>
-        <slf4j.version>1.7.5</slf4j.version>
-        <santuario.xmlsec.version>1.5.6</santuario.xmlsec.version>
-        <click.version>2.3.0</click.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
-        <commons-codec.version>1.6</commons-codec.version>
-        <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-digester.version>2.1</commons-digester.version>
-        <commons-fileupload.version>1.3.3</commons-fileupload.version>
-        <commons-io.version>2.3</commons-io.version>
-        <commons-lang.version>2.6</commons-lang.version>
-        <commons-logging.version>1.1.3</commons-logging.version>
-        <commons-logging-api.version>1.1</commons-logging-api.version>
         <esapiport.version>2013-12-04</esapiport.version>
-        <geoip.version>2.0.0</geoip.version>
-        <groovy.version>2.4.6</groovy.version>
-        <groovy-sandbox.version>1.6</groovy-sandbox.version>
-        <jaxb.version>1.0.6</jaxb.version>
-        <jaxb1.version>2.0.2</jaxb1.version>
-        <jaxrpc-api.version>1.1</jaxrpc-api.version>
-        <jaxrpc-impl.version>1.1.3_01</jaxrpc-impl.version>
-        <jaxrpc-spi.version>1.1.3_01</jaxrpc-spi.version>
-        <jdom.version>2.0.1</jdom.version>
-        <je.version>5.0.104</je.version>
-        <jersey-bundle.version>1.1.1-ea</jersey-bundle.version>
         <jato.version>2005-05-04</jato.version>
         <cc-ui.version>2008-08-08</cc-ui.version>
-        <jsr311-api.version>1.1.1</jsr311-api.version>
-        <jstl.version>1.1.2</jstl.version>
         <log4j.version>1.2.16</log4j.version>
-        <mail.version>1.5.1</mail.version>
-        <jersey-oauth.version>1.1.5.2</jersey-oauth.version>
-        <relaxngDatatype.version>20020414</relaxngDatatype.version>
-        <rhino.version>1.7R4</rhino.version>
-        <saaj-api.version>1.3.4</saaj-api.version>
-        <saaj-impl.version>1.3.19</saaj-impl.version>
-        <jsp-api.version>2.1</jsp-api.version>
-        <xsdlib.version>20060615</xsdlib.version>
         <authapi.version>2005-08-12</authapi.version>
         <jdmk.version>2007-01-10</jdmk.version>
-        <javax.security.auth.message.version>3.1</javax.security.auth.message.version>
-        <freemarker.version>2.3.19</freemarker.version>
-        <java-ipv6.version>0.14</java-ipv6.version>
-        <json.version>20090211</json.version>
-        <hikaricp.version>2.4.1</hikaricp.version>
-        <h2database.version>1.4.188</h2database.version>
-        <activemq.version>5.13.3</activemq.version>
-        <javax.inject.version>1_2</javax.inject.version>
-        <fastinfoset.version>1.2.13</fastinfoset.version>
+<!--        <hikaricp.version>2.4.1</hikaricp.version> -->
+<!--        <h2database.version>1.4.188</h2database.version> -->
+<!--        <activemq.version>5.13.3</.version> -->
         <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
 
         <openam.version>OpenAM ${project.version}</openam.version>
@@ -1009,461 +967,66 @@
             </dependency>
 
             <!-- External project dependencies -->
-            <dependency>
-                <groupId>org.apache.click</groupId>
-                <artifactId>click-extras</artifactId>
-                <version>${click.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>org.apache.click</groupId>
-                <artifactId>click-nodeps</artifactId>
-                <version>${click.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>${commons-codec.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-digester</groupId>
-                <artifactId>commons-digester</artifactId>
-                <version>${commons-digester.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>${commons-fileupload.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${commons-logging.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging-api</artifactId>
-                <version>${commons-logging-api.version}</version>
-            </dependency>
 
             <!-- Mozilla Rhino Javascript engine -->
-            <dependency>
-                <groupId>org.mozilla</groupId>
-                <artifactId>rhino</artifactId>
-                <version>${rhino.version}</version>
-            </dependency>
 
             <!-- Groovy scripting support -->
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-jsr223</artifactId>
-                <version>${groovy.version}</version>
-            </dependency>
 
             <!-- Groovy JSON parsing support -->
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-json</artifactId>
-                <version>${groovy.version}</version>
-            </dependency>
-
-            <dependency>
-                <!-- MIT licensed: http://groovy-sandbox.kohsuke.org/license.html -->
-                <groupId>org.kohsuke</groupId>
-                <artifactId>groovy-sandbox</artifactId>
-                <version>${groovy-sandbox.version}</version>
-                <!-- Groovy-sandbox depends on Groovy 1.8.5, so ignore that in favour of our version. -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.owasp.esapi</groupId>
-                <artifactId>esapi</artifactId>
-                <version>2.1.0.1</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xerces</groupId>
-                        <artifactId>xercesImpl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xalan</groupId>
-                        <artifactId>xalan</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis-ext</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-beanutils</groupId>
-                        <artifactId>commons-beanutils-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xom</groupId>
-                        <artifactId>xom</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.beanshell</groupId>
-                        <artifactId>bsh-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
             <!-- Override dependency for ESAPI -->
-            <dependency>
-                <groupId>org.apache-extras.beanshell</groupId>
-                <artifactId>bsh</artifactId>
-                <version>2.0b6</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.io7m.xom</groupId>
-                <artifactId>xom</artifactId>
-                <version>1.2.10</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xerces</groupId>
-                        <artifactId>xercesImpl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xalan</groupId>
-                        <artifactId>xalan</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
 
-            <dependency>
-                <groupId>org.owasp.antisamy</groupId>
-                <artifactId>antisamy</artifactId>
-                <version>1.5.7</version>
-            </dependency>
 
-            <dependency>
-                <groupId>org.apache.xmlgraphics</groupId>
-                <artifactId>batik-css</artifactId>
-                <version>1.10</version>
-            </dependency>
 
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.4.1</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.maxmind.geoip2</groupId>
-                <artifactId>geoip2</artifactId>
-                <version>${geoip.version}</version>
-            </dependency>
 
             <!-- TODO j2ee -->
 
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb1-impl</artifactId>
-                <version>${jaxb1.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-libs</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-xjc</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>javax.xml</groupId>
-                <artifactId>jaxrpc-api</artifactId>
-                <version>${jaxrpc-api.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.rpc</groupId>
-                <artifactId>jaxrpc-impl</artifactId>
-                <version>${jaxrpc-impl.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.xml.rpc</groupId>
-                <artifactId>jaxrpc-spi</artifactId>
-                <version>${jaxrpc-spi.version}</version>
-            </dependency>
 
             <!-- TODO jmx -->
 
-            <dependency>
-                <groupId>org.jdom</groupId>
-                <artifactId>jdom</artifactId>
-                <version>${jdom.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sleepycat</groupId>
-                <artifactId>je</artifactId>
-                <version>${je.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-bundle</artifactId>
-                <version>${jersey-bundle.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.iplanet.jato</groupId>
-                <artifactId>jato</artifactId>
-                <version>${jato.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc</artifactId>
-                <version>${cc-ui.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_de</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_es</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_fr</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_it</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_ja</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_ko</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_sv</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_zh</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_zh_CN</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_zh_HK</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.web.ui</groupId>
-                <artifactId>cc_zh_TW</artifactId>
-                <version>${cc-ui.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>${jsr311-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>jstl</artifactId>
-                <version>${jstl.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
-                <version>${mail.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-client</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-server</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-signature</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>relaxngDatatype</groupId>
-                <artifactId>relaxngDatatype</artifactId>
-                <version>${relaxngDatatype.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.xml.soap</groupId>
-                <artifactId>saaj-api</artifactId>
-                <version>${saaj-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.messaging.saaj</groupId>
-                <artifactId>saaj-impl</artifactId>
-                <version>${saaj-impl.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.fastinfoset</groupId>
-                <artifactId>FastInfoset</artifactId>
-                <version>${fastinfoset.version}</version>
-            </dependency>
 
 
-            <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>jsp-api</artifactId>
-                <version>${jsp-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
 
-            <dependency>
-                <groupId>com.sun.msv.datatype.xsd</groupId>
-                <artifactId>xsdlib</artifactId>
-                <version>${xsdlib.version}</version>
-            </dependency>
 
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.7</version>
-            </dependency>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
             <!-- OpenDJ API -->
             <dependency>
@@ -1504,24 +1067,6 @@
             <!-- We need to eventually ween off of these -->
 
             <!-- Dependencies for the Build Helper Maven Plugin -->
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-plugin-api</artifactId>
-                <version>3.0.5</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-project</artifactId>
-                <version>3.0-alpha-2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>3.3</version>
-                <scope>provided</scope>
-            </dependency>
 
             <dependency>
                 <groupId>jp.openam.external</groupId>
@@ -1541,97 +1086,8 @@
             </dependency>
 
             <!-- Preferred JSON Data Binding API -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
 
             <!-- Session HA Module Dependencies-->
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.jackson</artifactId>
-                <version>${restlet.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.json</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.xml</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.servlet</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.freemarker</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.ssl</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.simple</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.crypto</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.httpclient</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.net</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.slf4j</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
 
             <!-- Commons Dependencies -->
             <dependency>
@@ -1644,77 +1100,11 @@
                 <artifactId>forgerock-bloomfilter-monitoring</artifactId>
                 <version>${forgerock.bloomfilter.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.0</version>
-            </dependency>
 
             <!-- JASPIC -->
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.security.auth.message</artifactId>
-                <version>${javax.security.auth.message.version}</version>
-            </dependency>
 
             <!-- DevicePrint -->
-            <dependency>
-                <groupId>org.freemarker</groupId>
-                <artifactId>freemarker</artifactId>
-                <version>${freemarker.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.googlecode.java-ipv6</groupId>
-                <artifactId>java-ipv6</artifactId>
-                <version>${java-ipv6.version}</version>
-            </dependency>
             <!-- Native Json Manipulation -->
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>${json.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>${guice.version}</version>
-                <!-- Exclude aopalliance dependency due to ambiguous licensing terms. -->
-                <classifier>no_aop</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                    <!-- Exclude javax.inject in favour of servicemix OSGi-compatible version -->
-                    <exclusion>
-                        <groupId>javax.inject</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
-                <version>${guice.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.inject</groupId>
-                        <artifactId>guice</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-assistedinject</artifactId>
-                <version>${guice.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.inject</groupId>
-                        <artifactId>guice</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-guice-core</artifactId>
@@ -1732,161 +1122,13 @@
                 <scope>test</scope>
             </dependency>
 
-            <dependency>
-                <!-- Use OSGi-compatible javax.inject to satisfy commons dependencies -->
-                <groupId>org.apache.servicemix.bundles</groupId>
-                <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
-                <version>${javax.inject.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jgrapht</groupId>
-                <artifactId>jgrapht-core</artifactId>
-                <version>0.9.1</version>
-            </dependency>
 
             <!--
               required by the STS and SAML libraries
               -->
-            <dependency>
-                <groupId>org.apache.santuario</groupId>
-                <artifactId>xmlsec</artifactId>
-                <version>${santuario.xmlsec.version}</version>
-            </dependency>
 
             <!-- Test dependency -->
-            <dependency>
-                <groupId>org.codehaus.jstestrunner</groupId>
-                <artifactId>jstestrunner-junit</artifactId>
-                <version>1.0.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert</artifactId>
-                <version>1.4</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>6.8.5</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>2.1.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.9.5</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.easymock</groupId>
-                <artifactId>easymock</artifactId>
-                <version>3.2</version>
-                <scope>test</scope>
-            </dependency>
             <!-- Powermock -->
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-support</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-easymock</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>httpunit</groupId>
-                <artifactId>httpunit</artifactId>
-                <version>1.7</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-servlet-tester</artifactId>
-                <version>7.0.0.pre5</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.mortbay.jetty</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-core</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-reflect</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng-common</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.12.1.GA</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2database.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-client</artifactId>
-                <version>${activemq.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <!-- License: legal/CC-Public-Domain.txt -->
-                <groupId>org.hdrhistogram</groupId>
-                <artifactId>HdrHistogram</artifactId>
-                <version>2.1.4</version>
-            </dependency>
-            <dependency>
-                <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>${hikaricp.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,10 @@
 
         <javadoc-utils.version>1.0.0</javadoc-utils.version>
         <ant.contrib.version>1.0b3</ant.contrib.version>
+        <jato.version>2005-05-04</jato.version>
         <cc-ui.version>2008-08-08</cc-ui.version>
+        <authapi.version>2005-08-12</authapi.version>
+        <jdmk.version>2007-01-10</jdmk.version>
 
         <openam.version>OpenAM ${project.version}</openam.version>
         <!--  Project web site -->
@@ -970,6 +973,11 @@
             <!-- TODO j2ee -->
 
             <!-- TODO jmx -->
+            <dependency>
+                <groupId>com.iplanet.jato</groupId>
+                <artifactId>jato</artifactId>
+                <version>${jato.version}</version>
+            </dependency>
             <dependency>
               <groupId>com.sun.web.ui</groupId>
               <artifactId>cc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,16 +129,6 @@
 
         <javadoc-utils.version>1.0.0</javadoc-utils.version>
         <ant.contrib.version>1.0b3</ant.contrib.version>
-        <esapiport.version>2013-12-04</esapiport.version>
-        <jato.version>2005-05-04</jato.version>
-        <cc-ui.version>2008-08-08</cc-ui.version>
-        <log4j.version>1.2.16</log4j.version>
-        <authapi.version>2005-08-12</authapi.version>
-        <jdmk.version>2007-01-10</jdmk.version>
-<!--        <hikaricp.version>2.4.1</hikaricp.version> -->
-<!--        <h2database.version>1.4.188</h2database.version> -->
-<!--        <activemq.version>5.13.3</.version> -->
-        <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
 
         <openam.version>OpenAM ${project.version}</openam.version>
         <!--  Project web site -->
@@ -969,8 +959,6 @@
             <!-- External project dependencies -->
 
 
-
-
             <!-- Mozilla Rhino Javascript engine -->
 
             <!-- Groovy scripting support -->
@@ -995,7 +983,6 @@
 
 
             <!-- TODO jmx -->
-
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
 
         <javadoc-utils.version>1.0.0</javadoc-utils.version>
         <ant.contrib.version>1.0b3</ant.contrib.version>
+        <cc-ui.version>2008-08-08</cc-ui.version>
 
         <openam.version>OpenAM ${project.version}</openam.version>
         <!--  Project web site -->
@@ -965,6 +966,81 @@
             <!-- Groovy JSON parsing support -->
 
             <!-- Override dependency for ESAPI -->
+
+            <!-- TODO j2ee -->
+
+            <!-- TODO jmx -->
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc</artifactId>
+              <version>${cc-ui.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_de</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_es</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_fr</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_it</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_ja</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_ko</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_sv</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_zh</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_zh_CN</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_zh_HK</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.sun.web.ui</groupId>
+              <artifactId>cc_zh_TW</artifactId>
+              <version>${cc-ui.version}</version>
+              <scope>runtime</scope>
+            </dependency>
 
             <!-- OpenDJ API -->
             <dependency>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
