### PR TITLE
Issue #39 Information for single logout stored in CTS is not updated

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/cts/impl/SAML2CTSPersistentStore.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/impl/SAML2CTSPersistentStore.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.cts.impl;
 
@@ -150,7 +151,7 @@ public class SAML2CTSPersistentStore implements SAML2TokenRepository {
             // Perform the Save of the Token to the Token Repository.
             SAMLToken samlToken = new SAMLToken(primaryKey, secondaryKey, expirationTime, samlObj);
             Token token = tokenAdapter.toToken(samlToken);
-            persistentStore.createAsync(token);
+            persistentStore.updateAsync(token);
         } catch (CoreTokenException e) {
             debug.error("SAML2CTSPersistentStore.saveSAML2Token(): failed to save SAML2 " +
                     "token using primary key:" + primaryKey, e);

--- a/openam-federation/OpenFM/src/main/java/org/forgerock/openam/authentication/Saml2SessionUpgradeHandler.java
+++ b/openam-federation/OpenFM/src/main/java/org/forgerock/openam/authentication/Saml2SessionUpgradeHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.authentication;
 
@@ -83,7 +84,6 @@ public class Saml2SessionUpgradeHandler implements SessionUpgradeHandler {
                 idpSession.setSession(newSSOToken);
                 if (SAML2FailoverUtils.isSAML2FailoverEnabled()) {
                     try {
-                        SAML2FailoverUtils.deleteSAML2Token(sessionIndex);
                         long expirationTime = currentTimeMillis() / 1000 + newSession.getTimeLeft();
                         SAML2FailoverUtils.saveSAML2TokenWithoutSecondaryKey(sessionIndex,
                                 new IDPSessionCopy(idpSession), expirationTime);


### PR DESCRIPTION
## Analysis

When SAML2 failover is enabled, OpenAM as SAML IdP stores IDPSessionCopy in CTS. 
IDPSessionCopy is information for single logout. 
It contains the SP entity IDs which the SSO token has been federated.
Therefore, OpenAM needs to update IDPSessionCopy every time it issues an assertion, but it is not actually updated.

In the IDPSSOUtil assertion generation process, it seems that `SAML2FailoverUtils.saveSAML2TokenWithoutSecondaryKey()` is called to update IDPSessionCopy.

```
openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/profile/IDPSSOUtil.java
  878     private static Assertion getAssertion(
 ...
 1110         //  Save to SAML2 Token Repository
 1111         try {
 1112             if (SAML2FailoverUtils.isSAML2FailoverEnabled()) {
 1113                 long sessionExpireTime = currentTimeMillis() / 1000 + (sessionProvider.getTimeLeft(session));
 1114                 SAML2FailoverUtils.saveSAML2TokenWithoutSecondaryKey(sessionIndex, new IDPSessionCopy(idpSession),
 1115                         sessionExpireTime);
 1116             }
 1117             if (SAML2Utils.debug.messageEnabled()) {
 1118                 SAML2Utils.debug.message(classMethod + "SAVE IDPSession!");
 1119             }
```

However, it is not actually updated.
`SAML2FailoverUtils.saveSAML2TokenWithoutSecondaryKey()` calls `SAML2CTSPersistentStore.saveSAML2Token()`, but when you look at that code, you can see that it doesn't support updates.

```
openam-core/src/main/java/org/forgerock/openam/cts/impl/SAML2CTSPersistentStore.java
 146     public void saveSAML2Token(String primaryKey, String secondaryKey, Object samlObj, long expirationTime)
 147             throws SAML2TokenRepositoryException {
 148 
 149         // Save the SAML2 Token.
 150         try {
 151             // Perform the Save of the Token to the Token Repository.
 152             SAMLToken samlToken = new SAMLToken(primaryKey, secondaryKey, expirationTime, samlObj);
 153             Token token = tokenAdapter.toToken(samlToken);
 154             persistentStore.createAsync(token);
 155         } catch (CoreTokenException e) {
 156             debug.error("SAML2CTSPersistentStore.saveSAML2Token(): failed to save SAML2 " +
 157                     "token using primary key:" + primaryKey, e);
 158             throw new SAML2TokenRepositoryException(e.getMessage(), e);
 159         }
 160     }

```

## Solution

Use `updateAsync()` instead of `createAsync()` when saving SAML2 tokens.
In addition, the token deletion process in Saml2SessionUpgradeHandler was deleted since it was unnecessary.

## Testing

* Try #39 "Steps to reproduce"
