### PR TITLE
Issue #3 XUI does not enable Secure cookie flags for SSO tracking cookie on 13.5.0

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/AuthenticationToken.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/AuthenticationToken.jsm
@@ -30,7 +30,7 @@ function cookieDomains () {
 }
 
 function secureCookie () {
-    return Configuration.globalData.auth.secureCookie;
+    return Configuration.globalData.secureCookie;
 }
 
 export function set (token) {

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/SessionToken.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/SessionToken.jsm
@@ -31,7 +31,7 @@ function cookieDomains () {
 }
 
 function secureCookie () {
-    return Configuration.globalData.auth.secureCookie;
+    return Configuration.globalData.secureCookie;
 }
 
 export function set (token) {


### PR DESCRIPTION
## Analysis

The processing of cookies on XUI has been modularized due to the modification of OPENAM-7996 (dec03c736080738684cbe22183fb5aa2761b9616).

However, these cookie modules are reading the secure flag setting from the wrong variable.

OK -> Configuration.globalData.secureCookie
NG -> Configuration.globalData.auth.secureCookie

## Solution

* cherry-pick OPENAM-9515 (4657dc7b8f8c2b6f1f203a2cd07e8bc02b407462)

## Testing

* Try #3 "Steps to reproduce"