### PR TITLE
Issue #67 ForgeRock AM/OpenAM Security Advisory 201801-02: Configuration password stored in plain text

### DIFF
--- a/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/JwtHandlerConfig.java
+++ b/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/JwtHandlerConfig.java
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2014 ForgeRock AS.
+ * Copyright 2014-2016 ForgeRock AS.
  */
 
 package org.forgerock.openam.authentication.modules.oidc;
@@ -30,6 +30,7 @@ public class JwtHandlerConfig {
     static final String ISSUER_NAME_KEY = "openam-auth-openidconnect-issuer-name";
     static final String CRYPTO_CONTEXT_TYPE_KEY = "openam-auth-openidconnect-crypto-context-type";
     static final String CRYPTO_CONTEXT_VALUE_KEY = "openam-auth-openidconnect-crypto-context-value";
+    static final String KEY_CLIENT_SECRET = "iplanet-am-auth-oauth-client-secret";
 
     static final String CRYPTO_CONTEXT_TYPE_CONFIG_URL = ".well-known/openid-configuration_url";
     static final String CRYPTO_CONTEXT_TYPE_JWK_URL = "jwk_url";
@@ -38,12 +39,14 @@ public class JwtHandlerConfig {
     protected final String configuredIssuer;
     protected final String cryptoContextType;
     protected final String cryptoContextValue;
+    protected final String clientSecret;
     private final URL cryptoContextUrlValue;
 
     public JwtHandlerConfig(Map options) {
         configuredIssuer = CollectionHelper.getMapAttr(options, ISSUER_NAME_KEY);
         cryptoContextType = CollectionHelper.getMapAttr(options, CRYPTO_CONTEXT_TYPE_KEY);
         cryptoContextValue = CollectionHelper.getMapAttr(options, CRYPTO_CONTEXT_VALUE_KEY);
+        clientSecret = CollectionHelper.getMapAttr(options, KEY_CLIENT_SECRET);
         Reject.ifFalse(cryptoContextType == null || CRYPTO_CONTEXT_TYPE_CLIENT_SECRET.equals(cryptoContextType) ||
                 CRYPTO_CONTEXT_TYPE_JWK_URL.equals(cryptoContextType) ||
                 CRYPTO_CONTEXT_TYPE_CONFIG_URL.equals(cryptoContextType), "The value corresponding to key " +
@@ -77,4 +80,7 @@ public class JwtHandlerConfig {
         return cryptoContextUrlValue;
     }
 
+    public String getClientSecret() {
+        return clientSecret;
+    }
 }

--- a/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/JwtHandlerConfig.java
+++ b/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/JwtHandlerConfig.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.authentication.modules.oidc;
@@ -27,14 +28,14 @@ import java.util.Map;
 public class JwtHandlerConfig {
     private static Debug logger = Debug.getInstance("amAuth");
 
-    static final String ISSUER_NAME_KEY = "openam-auth-openidconnect-issuer-name";
-    static final String CRYPTO_CONTEXT_TYPE_KEY = "openam-auth-openidconnect-crypto-context-type";
-    static final String CRYPTO_CONTEXT_VALUE_KEY = "openam-auth-openidconnect-crypto-context-value";
-    static final String KEY_CLIENT_SECRET = "iplanet-am-auth-oauth-client-secret";
+    public static final String ISSUER_NAME_KEY = "openam-auth-openidconnect-issuer-name";
+    public static final String CRYPTO_CONTEXT_TYPE_KEY = "openam-auth-openidconnect-crypto-context-type";
+    public static final String CRYPTO_CONTEXT_VALUE_KEY = "openam-auth-openidconnect-crypto-context-value";
+    public static final String KEY_CLIENT_SECRET = "iplanet-am-auth-oauth-client-secret";
 
-    static final String CRYPTO_CONTEXT_TYPE_CONFIG_URL = ".well-known/openid-configuration_url";
-    static final String CRYPTO_CONTEXT_TYPE_JWK_URL = "jwk_url";
-    static final String CRYPTO_CONTEXT_TYPE_CLIENT_SECRET = "client_secret";
+    public static final String CRYPTO_CONTEXT_TYPE_CONFIG_URL = ".well-known/openid-configuration_url";
+    public static final String CRYPTO_CONTEXT_TYPE_JWK_URL = "jwk_url";
+    public static final String CRYPTO_CONTEXT_TYPE_CLIENT_SECRET = "client_secret";
 
     protected final String configuredIssuer;
     protected final String cryptoContextType;

--- a/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/OpenIdConnectConfig.java
+++ b/openam-authentication/openam-auth-oidc/src/main/java/org/forgerock/openam/authentication/modules/oidc/OpenIdConnectConfig.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.openam.authentication.modules.oidc;
@@ -71,7 +72,6 @@ class OpenIdConnectConfig extends JwtHandlerConfig {
         Reject.ifNull(headerName, HEADER_NAME_KEY + " must be set in LoginModule options.");
         Reject.ifNull(configuredIssuer, ISSUER_NAME_KEY + " must be set in LoginModule options.");
         Reject.ifNull(cryptoContextType, CRYPTO_CONTEXT_TYPE_KEY + " must be set in LoginModule options.");
-        Reject.ifNull(cryptoContextValue, CRYPTO_CONTEXT_VALUE_KEY + " must be set in LoginModule options.");
         Reject.ifNull(principalMapperClass, PRINCIPAL_MAPPER_CLASS_KEY + " must be set in LoginModule options.");
         Reject.ifNull(configuredJwkToLocalAttributeMappings, JWK_TO_LOCAL_ATTRIBUTE_MAPPINGS_KEY + " must be set in LoginModule options.");
         Reject.ifTrue(configuredJwkToLocalAttributeMappings.isEmpty(), JWK_TO_LOCAL_ATTRIBUTE_MAPPINGS_KEY + " must contain some valid mappings.");

--- a/openam-authentication/openam-auth-oidc/src/main/resources/amAuthOpenIdConnect.properties
+++ b/openam-authentication/openam-auth-oidc/src/main/resources/amAuthOpenIdConnect.properties
@@ -21,7 +21,7 @@ issuer_name.help= Value must match the iss field in issued ID Token
 crypto_context_type=OpenID Connect validation configuration type
 crypto_context_type.help=Please select either 1. the issuer discovery url, 2. the issuer jwk url, or 3. the client_secret.
 crypto_context_value=OpenID Connect validation configuration value
-crypto_context_value.help=The discovery url, or jwk url, or the client_secret, corresponding to the selection above.
+crypto_context_value.help=The discovery url, or jwk url, corresponding to the selection above.
 crypto_context_value.help.txt=If discovery or jwk url entered, entry must be in valid url format.
 principal_mapper_class=Principal mapper class
 principal_mapper_class.help=Class which implements mapping of jwt state to a Principal in the local identity repository
@@ -61,3 +61,4 @@ invalid_authorized_party=ID token was received from invalid authorized party.
 authorized_party_not_in_audience=Authorized party was present in ID token, but its value was not found in the \
   audience claim.
 no_audience_claim=No audience claim present in ID token.
+client_secret=Client Secret

--- a/openam-authentication/openam-auth-oidc/src/main/resources/amAuthOpenIdConnect.xml
+++ b/openam-authentication/openam-auth-oidc/src/main/resources/amAuthOpenIdConnect.xml
@@ -65,11 +65,14 @@
                 </AttributeSchema>
                 <AttributeSchema name="openam-auth-openidconnect-crypto-context-value"
                                  type="single" syntax="string" i18nKey="crypto_context_value" order="300"
-                                 validator="RequiredValueValidator"
                                  resourceName="cryptoContextValue">
                     <DefaultValues>
                         <Value>https://accounts.google.com/.well-known/openid-configuration</Value>
                     </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="iplanet-am-auth-oauth-client-secret"
+                                 type="single" syntax="password" i18nKey="client_secret" order="301"
+                                 resourceName="clientSecret">
                 </AttributeSchema>
                 <AttributeSchema name="openam-auth-openidconnect-account-provider-class"
                                  type="single" syntax="string" i18nKey="account_provider_class" order="100"
@@ -165,11 +168,14 @@
                     </AttributeSchema>
                     <AttributeSchema name="openam-auth-openidconnect-crypto-context-value"
                                      type="single" syntax="string" i18nKey="crypto_context_value" order="300"
-                                     validator="RequiredValueValidator"
                                      resourceName="cryptoContextValue">
                         <DefaultValues>
                             <Value>https://accounts.google.com/.well-known/openid-configuration</Value>
                         </DefaultValues>
+                    </AttributeSchema>
+                    <AttributeSchema name="iplanet-am-auth-oauth-client-secret"
+                                     type="single" syntax="password" i18nKey="client_secret" order="301"
+                                     resourceName="clientSecret">
                     </AttributeSchema>
                     <AttributeSchema name="openam-auth-openidconnect-account-provider-class"
                                      type="single" syntax="string" i18nKey="account_provider_class" order="100"

--- a/openam-console/src/main/java/com/sun/identity/console/agentconfig/AgentDumpViewBean.java
+++ b/openam-console/src/main/java/com/sun/identity/console/agentconfig/AgentDumpViewBean.java
@@ -25,6 +25,7 @@
  * $Id: AgentDumpViewBean.java,v 1.1 2008/12/10 18:25:14 farble1670 Exp $
  *
  * Portions Copyrighted 2011-2014 ForgeRock AS.
+ * Portions Copyrighted 2019 Open Source Solution Technology Corporation
  */
 package com.sun.identity.console.agentconfig;
 
@@ -131,6 +132,9 @@ public class AgentDumpViewBean extends AMPrimaryMastHeadViewBean
                     );
             AgentDumpModel model = (AgentDumpModel)getModel();
             Map values = model.getAttributeValues(universalId);
+
+            // Remove userpassword attribute from Agent configuration export page
+            values.remove("userpassword");
 
             CCStaticTextField valuesText =
                     (CCStaticTextField)getChild(STATICTEXT_VALUES);

--- a/openam-core/src/main/resources/amUpgrade.properties
+++ b/openam-core/src/main/resources/amUpgrade.properties
@@ -23,6 +23,7 @@
 #
 
 # Portions Copyrighted 2014 Nomura Research Institute, Ltd
+# Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 report=OpenAM Upgrade Report%LF%=====================%LF%Created: %CREATED_DATE%%LF%%LF%Existing Version: %EXISTING_VERSION%%LF%New Version: %NEW_VERSION%%LF%%LF%
 upgrade.servicereport=Services Upgrade Report%LF%-----------------------%LF%%LF%New Services%LF%%LF%%NEW_SERVICES%%LF%%LF%Modified Services%LF%%LF%%MODIFIED_SERVICES%%LF%%LF%New Schemas%LF%%LF%%NEW_SCHEMAS%%LF%%LF%New Sub Schemas%LF%%LF%%NEW_SUB_SCHEMAS%%LF%%LF%Deleted Services%LF%%LF%%DELETED_SERVICES%%LF%%LF%
@@ -246,3 +247,8 @@ upgrade.auditservice.start=Upgrading i18nFileNames in AuditService
 upgrade.auditservice.short=Update i18nFileName attributes in AuditService
 upgrade.auditservice.detailed=AuditService upgrade report%LF%---------------------------%LF%Updating i18nFileName \
   attributes from "commonAudit" to "audit"%LF%
+
+# OpenID Connect id_token bearer module upgrade
+upgrade.openidconnect.auth.modules=OpenID Connect id_token bearer Modules modified
+upgrade.openidconnect.auth.modules.report=OpenID Connect id_token bearer Module Upgrade Report%LF%----------------------------%LF%%REPORT_DATA%%LF%
+upgrade.openidconnect.auth.modules.updated=%LF%The following modules were automatically updated:%LF%%REPORT_DATA%

--- a/openam-upgrade/pom.xml
+++ b/openam-upgrade/pom.xml
@@ -61,6 +61,10 @@
         </dependency>
         <dependency>
             <groupId>jp.openam</groupId>
+            <artifactId>openam-auth-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jp.openam</groupId>
             <artifactId>openam-entitlements</artifactId>
         </dependency>
         <dependency>

--- a/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/steps/UpgradeOpenIdConnectAuthModulesStep.java
+++ b/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/steps/UpgradeOpenIdConnectAuthModulesStep.java
@@ -1,0 +1,165 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2019 Open Source Solution Technology Corporation
+ */
+
+package jp.co.osstech.openam.upgrade.steps;
+
+import static org.forgerock.openam.upgrade.UpgradeServices.*;
+import static org.forgerock.openam.utils.CollectionUtils.*;
+import static org.forgerock.openam.authentication.modules.oidc.JwtHandlerConfig.*;
+
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.forgerock.openam.sm.datalayer.api.ConnectionFactory;
+import org.forgerock.openam.sm.datalayer.api.ConnectionType;
+import org.forgerock.openam.sm.datalayer.api.DataLayer;
+import org.forgerock.openam.upgrade.UpgradeException;
+import org.forgerock.openam.upgrade.UpgradeStepInfo;
+import org.forgerock.openam.upgrade.steps.AbstractUpgradeStep;
+
+import com.iplanet.sso.SSOToken;
+import com.sun.identity.sm.ServiceConfig;
+import com.sun.identity.sm.ServiceConfigManager;
+import com.sun.identity.sm.ServiceNotFoundException;
+
+/**
+ * This upgrade step looks in OpenID Connect id_token bearer module config to convert crypto-context-value
+ * into client_secret.
+ */
+@UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.UpgradeServiceSchemaStep")
+public class UpgradeOpenIdConnectAuthModulesStep extends AbstractUpgradeStep {
+
+    private static final String REPORT_DATA = "%REPORT_DATA%";
+    private static final String SERVICE_NAME = "iPlanetAMAuthOpenIdConnectService";
+    private Map<String, Set<String>> affectedRealms = new HashMap<String, Set<String>>();
+    private int moduleCount = 0;
+
+    @Inject
+    public UpgradeOpenIdConnectAuthModulesStep(final PrivilegedAction<SSOToken> adminTokenAction,
+            @DataLayer(ConnectionType.DATA_LAYER) final ConnectionFactory factory) {
+        super(adminTokenAction, factory);
+    }
+
+    @Override
+    public void initialize() throws UpgradeException {
+        try {
+            ServiceConfigManager scm = new ServiceConfigManager(SERVICE_NAME, getAdminToken());
+            for (String realm : getRealmNames()) {
+                ServiceConfig realmConfig = scm.getOrganizationConfig(realm, null);
+                for (String moduleName : (Set<String>) realmConfig.getSubConfigNames()) {
+                    ServiceConfig moduleConfig = realmConfig.getSubConfig(moduleName);
+                    Map<String, Set<?>> attributes = getAttributes(moduleConfig);
+                    check(attributes, realm, moduleName);
+                }
+            }
+        } catch (ServiceNotFoundException e) {
+            DEBUG.message("OpenID Connect id_token bearer modules not found. Nothing to upgrade", e);
+        } catch (Exception ex) {
+            DEBUG.error("An error occurred while trying to look for upgradable OpenID Connect id_token bearer modules", ex);
+            throw new UpgradeException("Unable to retrieve OpenID Connect id_token bearer modules", ex);
+        }
+    }
+
+    private Map<String, Set<?>> getAttributes(ServiceConfig moduleConfig) {
+        return moduleConfig.getAttributes();
+    }
+
+    private void check(Map<String, Set<?>> attributes, String realm, String moduleName) {
+        if (attributes.get(CRYPTO_CONTEXT_TYPE_KEY).contains(CRYPTO_CONTEXT_TYPE_CLIENT_SECRET)
+                && isNotEmpty(attributes.get(CRYPTO_CONTEXT_VALUE_KEY))
+                && isEmpty(attributes.get(KEY_CLIENT_SECRET))) {
+            moduleCount++;
+            flagModule(realm, moduleName);
+        }
+    }
+
+    private void flagModule(String realm, String moduleName) {
+        if (affectedRealms.containsKey(realm)) {
+            affectedRealms.get(realm).add(moduleName);
+        } else {
+            affectedRealms.put(realm, asSet(moduleName));
+        }
+    }
+
+    @Override
+    public boolean isApplicable() {
+        return !affectedRealms.isEmpty();
+    }
+
+    @Override
+    public void perform() throws UpgradeException {
+        try {
+            ServiceConfigManager scm = new ServiceConfigManager(SERVICE_NAME, getAdminToken());
+            for (Map.Entry<String, Set<String>> realm : affectedRealms.entrySet()) {
+                ServiceConfig realmConfig = scm.getOrganizationConfig(realm.getKey(), null);
+                for (String moduleName : realm.getValue()) {
+                    ServiceConfig moduleConfig = realmConfig.getSubConfig(moduleName);
+                    Map<String, Set<?>> attributes = getAttributes(moduleConfig);
+                    Map<String, Set<?>> attribute = new HashMap();
+                    attribute.put(KEY_CLIENT_SECRET, attributes.get(CRYPTO_CONTEXT_VALUE_KEY));
+                    moduleConfig.setAttributes(attribute);
+                    attribute = new HashMap();
+                    attribute.put(CRYPTO_CONTEXT_VALUE_KEY, asSet(""));
+                    moduleConfig.setAttributes(attribute);
+                }
+            }
+        } catch (Exception ex) {
+            DEBUG.error("An error occurred while trying to update OpenID Connect id_token bearer modules", ex);
+            throw new UpgradeException("Unable to update OpenID Connect id_token bearer modules", ex);
+        }
+    }
+
+    @Override
+    public String getShortReport(String delimiter) {
+        StringBuilder sb = new StringBuilder();
+        if (moduleCount != 0) {
+            sb.append(BUNDLE.getString("upgrade.openidconnect.auth.modules")).append(" (").append(moduleCount).append(')')
+                    .append(delimiter);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getDetailedReport(String delimiter) {
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put(LF, delimiter);
+        StringBuilder sb = new StringBuilder();
+        sb.append(getModulesReport("upgrade.openidconnect.auth.modules.updated", delimiter, affectedRealms));
+        tags.put(REPORT_DATA, sb.toString());
+        return tagSwapReport(tags, "upgrade.openidconnect.auth.modules.report");
+    }
+
+    private String getModulesReport(String messageKey, String delimiter, Map<String, Set<String>> flags) {
+        if (flags.isEmpty()) {
+            return "";
+        }
+        Map<String, String> tags = new HashMap<String, String>();
+        tags.put(LF, delimiter);
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Set<String>> entry : flags.entrySet()) {
+            sb.append(BUNDLE.getString("upgrade.realm")).append(": ").append(entry.getKey()).append(delimiter);
+            for (String module : entry.getValue()) {
+                sb.append(INDENT).append(module).append(delimiter);
+            }
+        }
+        tags.put(REPORT_DATA, sb.toString());
+        return tagSwapReport(tags, messageKey);
+    }
+}

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/OpenIdConnectAuthModuleServiceHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/OpenIdConnectAuthModuleServiceHelper.java
@@ -12,9 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 package org.forgerock.openam.upgrade.helpers;
 
+import org.forgerock.openam.authentication.modules.oidc.JwtHandlerConfig;
 import org.forgerock.openam.upgrade.UpgradeException;
 
 import com.sun.identity.sm.AbstractUpgradeHelper;
@@ -32,10 +34,19 @@ public class OpenIdConnectAuthModuleServiceHelper extends AbstractUpgradeHelper 
     public OpenIdConnectAuthModuleServiceHelper() {
         attributes.add(PRINCIPAL_MAPPER_ATTR);
         attributes.add(ACCOUNT_PROVIDER_ATTR);
+        attributes.add(JwtHandlerConfig.CRYPTO_CONTEXT_VALUE_KEY);
     }
 
     @Override
     public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl oldAttr, AttributeSchemaImpl newAttr) throws UpgradeException {
+
+        // Remove validator from openam-auth-openidconnect-crypto-context-value
+        if (JwtHandlerConfig.CRYPTO_CONTEXT_VALUE_KEY.equals(newAttr.getName())) {
+            if (oldAttr.getValidator() != null) {
+                return newAttr;
+            }
+        }
+
         if (!newAttr.getI18NKey().equals(oldAttr.getI18NKey())) {
             return newAttr;
         }


### PR DESCRIPTION
## Solution

* Adjust agent configuration export page
* cherry-pick OPENAM-9760
* Add client secret field in setting of OIDC id_token bearer authentication
