### PR TITLE
Issue #188 Broken layout of setup screen

### DIFF
--- a/openam-server-only/src/main/webapp/assets/css/Specific/wizard.css
+++ b/openam-server-only/src/main/webapp/assets/css/Specific/wizard.css
@@ -48,8 +48,13 @@
 	vertical-align: middle;
 }
 
+.scroll {
+	padding-right:10px;
+	height: 535px;
+}
+
 .tabContents {
-	padding: 0em 1em 0em 0em;				
+	padding: 0em 0em 0em 0em;				
 }
 
 #tab1RequiredInfoPanel li {
@@ -58,9 +63,10 @@
 }
 
 .tabContent {
+	width: 620px;
 	height: 535px;
+	margin-left: 180px;
 	border-left:1px solid #999999;
-	margin-left:170px;		
 }
 
 .tabContent h1 {
@@ -143,7 +149,7 @@
 }
 
 .summaryPanel .bodyBox {
-	height: 100px;
+	height: auto;
 }
 
 .summaryPanel ol {

--- a/openam-server-only/src/main/webapp/assets/css/style.css
+++ b/openam-server-only/src/main/webapp/assets/css/style.css
@@ -562,6 +562,9 @@ div.borderPopUpGray{
     /* border: 1px solid #0094d4; */
     border: 1px solid #0094d4;
     border-bottom: none;
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 input.text, input[type="text"], input[type="checkbox"] {
     padding: 2px;

--- a/openam-server-only/src/main/webapp/config/wizard/step1.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step1.htm
@@ -31,15 +31,15 @@
     YAHOO.util.Event.onDOMReady(initStep1);
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("step1.title")<img class="pointer" src="$context/assets/images/message.gif"/></h1>
     <p>$page.getLocalizedString("step1.description")</p>
     
-    <div class="summaryPanel" style="width:610px">
+    <div class="summaryPanel" style="width:100%;">
         <p id="allfields"><em>*</em>&nbsp;$page.getLocalizedString("required.field.label")</p>
       <b class="xtop"><b class="xt1"></b><b class="xt2"></b><b class="xt3"></b><b class="xt4"></b></b>
       <div class="headerBox">$page.getLocalizedString("step1.subtitle")</div>
-        <div class="bodyBox"  style="height:180px">
+        <div class="bodyBox"  style="max-height:335px;">
             <span>
                 <table class="temp">
                     <tr>

--- a/openam-server-only/src/main/webapp/config/wizard/step2.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step2.htm
@@ -84,15 +84,15 @@
 
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px">
 <h1>$page.getLocalizedString("step2.title")<img class="pointer" src="$context/assets/images/message.gif"/></h1>
 <p>$page.getLocalizedString("step2.description")</p>
 
-<div id="serverSettingsDiv" style="width:610px;">
+<div id="serverSettingsDiv" style="width:100%;">
     <p id="allfields"><em>*</em>&nbsp;$page.getLocalizedString("required.field.label")</p>
     <b class="xtop"><b class="xt1"></b><b class="xt2"></b><b class="xt3"></b><b class="xt4"></b></b>
     <div class="headerBox" >$page.getLocalizedString("step2.server.settings")</div>
-    <div class="bodyBox" style="height:220px;">	
+    <div class="bodyBox" style="max-height:365px;">	
         <span>
             <table class="temp">
                 <tr>

--- a/openam-server-only/src/main/webapp/config/wizard/step3.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step3.htm
@@ -381,17 +381,18 @@
     YAHOO.util.Event.onDOMReady(initConfig);
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("step3.title")<img class="pointer" 
         src="$context/assets/images/message.gif"/></h1>
     <p>$page.getLocalizedString("step3.description")</p> 
-    <input type="radio" id="existingNo" name="existingInstance" value="false" onclick="disableExisting();" $selectFirstSetup />
-        $page.getLocalizedString("create.new.instance")
-    <input type="radio" id="existingYes" name="existingInstance" value="true" onclick="enableExisting();" $selectExistingSetup />
-        $page.getLocalizedString("add.existing.instance")
+    <input type="radio" style="margin-left:1em;" id="existingNo" name="existingInstance" value="false" onclick="disableExisting();" $selectFirstSetup />
+        <span>$page.getLocalizedString("create.new.instance")</span>
+        <br>
+    <input type="radio" style="margin-left:1em;" id="existingYes" name="existingInstance" value="true" onclick="enableExisting();" $selectExistingSetup />
+        <span>$page.getLocalizedString("add.existing.instance")</span>
        
     <!-- EMBEDDED STORE PROPERTIES -->
-    <div id="configStoreProperties" style="width:620px;" >
+    <div id="configStoreProperties" style="width:100%;" >
         <p id="allfields"><em>*</em>&nbsp;
             $page.getLocalizedString("required.field.label")</p>
         <b class="xtop">
@@ -403,7 +404,7 @@
         <div class="headerBox">
             $page.getLocalizedString("step3.sub.title")
         </div>
-        <div class="bodyBox" style="height:290px;">
+        <div class="bodyBox" style="max-height:330px;">
              <span>  
              <!-- New Instances -->
              <div id="newInstanceOptions">            
@@ -548,7 +549,7 @@
                     </tr>  
                     <tr>
                         <td>&nbsp;</td>
-                        <td>
+                        <td style="padding-left:1em;">
                             <small>$page.getLocalizedString("url.server.help")</small>                    
                         </td>
                     </tr>              

--- a/openam-server-only/src/main/webapp/config/wizard/step4.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step4.htm
@@ -273,14 +273,14 @@
 
     <label for="userStoreDefault" style="float:none">
         <input type="radio" id="userStoreDefault" name="userStoreCustom"
-            style="margin-left:1em" value="false" $selectEmbeddedUM
+            style="margin-left:1em;" value="false" $selectEmbeddedUM
             $radioDataTypeDisabled onclick="enableEmbeddedConfig();"/>
-        <span>$page.getLocalizedString("configurator.embedded")</span><br/>
+        <span>$page.getLocalizedString("configurator.embedded")</span>
     </label>
-
+    <br>
     <label for="userStoreCustom" style="float:none">
         <input type="radio" id="userStoreCustom" name="userStoreCustom"
-            value="true" $selectExternalUM
+            style="margin-left:1em;" value="true" $selectExternalUM
             $radioDataTypeDisabled onclick="enableExternalConfig();"/>
         <span>$page.getLocalizedString("configurator.remote")</span>
     </label>

--- a/openam-server-only/src/main/webapp/config/wizard/step4.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step4.htm
@@ -267,7 +267,7 @@
     YAHOO.util.Event.onDOMReady(initUserStorePage);
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("step4.title")<img class="pointer" src="$context/assets/images/message.gif"/></h1>
     <p>$page.getLocalizedString("step4.description")</p>
 
@@ -280,12 +280,12 @@
 
     <label for="userStoreCustom" style="float:none">
         <input type="radio" id="userStoreCustom" name="userStoreCustom"
-            style="margin-left:1em" value="true" $selectExternalUM
+            value="true" $selectExternalUM
             $radioDataTypeDisabled onclick="enableExternalConfig();"/>
         <span>$page.getLocalizedString("configurator.remote")</span>
     </label>
     
-    <div id="userStoreModule" style="width:610px;">
+    <div id="userStoreModule" style="width:100%;">
         <p id="allfields"><em>*</em>&nbsp;$page.getLocalizedString("required.field.label")</p>
         <b class="xtop">
             <b class="xt1"></b>
@@ -294,7 +294,7 @@
             <b class="xt4"></b>
         </b>
         <div class="headerBox">$page.getLocalizedString("step4.sub.title")</div>
-        <div class="bodyBox" style="height:270px;">
+        <div class="bodyBox" style="max-height:300px;">
             <div id="embeddedConfigSettings"
                 style="margin-left:10px; display:none">
                 <br>
@@ -303,21 +303,21 @@
             </div>
             <span id="externalConfigSettings" style="display:none">
                 <table class="temp" style="margin-bottom: 0">
+                    <tr><td valign="top"><em>*&nbsp;</em>$page.getLocalizedString("store.type.label")</td></tr>
                     <tr>
-                        <td valign="top"><em>*&nbsp;</em>$page.getLocalizedString("store.type.label")</td>
                         <td>
                             <table id="userStoreCustomTypes">
                                 <tr>
-                                    <td><label for="ldapv3opends" style="float:none"><input type="radio" id="ldapv3opends" name="userStoreType" value="LDAPv3ForOpenDS" $selectLDAPv3opends onclick="setOpenDS();"/>&nbsp;$page.getLocalizedString("opends.ldap.schema")</label></td>
-                                    <td><label for="ldapv3odsee" style="float:none"><input type="radio" id="ldapv3odsee" name="userStoreType" value="LDAPv3ForODSEE" $selectLDAPv3odsee onclick="setODSEE();"/>&nbsp;$page.getLocalizedString("odsee.ldap.schema")</label></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3opends" style="float:none"><input type="radio" id="ldapv3opends" name="userStoreType" value="LDAPv3ForOpenDS" $selectLDAPv3opends onclick="setOpenDS();"/>&nbsp;$page.getLocalizedString("opends.ldap.schema")</label></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3odsee" style="float:none"><input type="radio" id="ldapv3odsee" name="userStoreType" value="LDAPv3ForODSEE" $selectLDAPv3odsee onclick="setODSEE();"/>&nbsp;$page.getLocalizedString("odsee.ldap.schema")</label></td>
                                 </tr>
                                 <tr>
-                                    <td><label for="ldapv3adforDomainName" style="float:none"><input type="radio" id="ldapv3adforDomainName" name="userStoreType" value="LDAPv3ForADDC" $selectLDAPv3addc onclick="setADforDomainName();"/>&nbsp;$page.getLocalizedString("activedirectoryfordomainname.ldap.schema")</label></td>
-                                    <td><label for="ldapv3ad" style="float:none"><input type="radio" id="ldapv3ad" name="userStoreType" value="LDAPv3ForAD" $selectLDAPv3ad onclick="setAD();"/>&nbsp;$page.getLocalizedString("activedirectory.ldap.schema")</label><br></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3adforDomainName" style="float:none"><input type="radio" id="ldapv3adforDomainName" name="userStoreType" value="LDAPv3ForADDC" $selectLDAPv3addc onclick="setADforDomainName();"/>&nbsp;$page.getLocalizedString("activedirectoryfordomainname.ldap.schema")</label></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3ad" style="float:none"><input type="radio" id="ldapv3ad" name="userStoreType" value="LDAPv3ForAD" $selectLDAPv3ad onclick="setAD();"/>&nbsp;$page.getLocalizedString("activedirectory.ldap.schema")</label><br></td>
                                 </tr>
                                 <tr>
-                                    <td><label for="ldapv3tivoli" style="float:none"><input type="radio" id="ldapv3tivoli" name="userStoreType" value="LDAPv3ForTivoli" $selectLDAPv3tivoli onclick="setTivoli();"/>&nbsp;$page.getLocalizedString("tivoli.ldap.schema")</label></td>
-                                    <td><label for="ldapv3adam" style="float:none"><input type="radio" id="ldapv3adam" name="userStoreType" value="LDAPv3ForADAM" $selectLDAPv3adam onclick="setADAM();"/>&nbsp;$page.getLocalizedString("adam.ldap.schema")</label></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3tivoli" style="float:none"><input type="radio" id="ldapv3tivoli" name="userStoreType" value="LDAPv3ForTivoli" $selectLDAPv3tivoli onclick="setTivoli();"/>&nbsp;$page.getLocalizedString("tivoli.ldap.schema")</label></td>
+                                    <td style="padding-left:2em;"><label for="ldapv3adam" style="float:none"><input type="radio" id="ldapv3adam" name="userStoreType" value="LDAPv3ForADAM" $selectLDAPv3adam onclick="setADAM();"/>&nbsp;$page.getLocalizedString("adam.ldap.schema")</label></td>
                                 </tr>
                             </table>
                         </td>

--- a/openam-server-only/src/main/webapp/config/wizard/step5.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step5.htm
@@ -123,17 +123,17 @@
 
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("step5.title")<img class="pointer" alt="info" src="$context/assets/images/message.gif"/></h1>
     <p>$page.getLocalizedString("step5.description")</p>
-    <input type="radio" id="loadBalancerDisable" #if (!$host && !$port) checked="checked"#{end}/><span>&nbsp;$page.getLocalizedString("no.label")</span><br/>
-    <input type="radio" id="loadBalancerEnable" #if ($host || $port) checked="checked"#{end}/><span>&nbsp;$page.getLocalizedString("yes.label")</span>
+    <input type="radio" style="margin-left:1em;" id="loadBalancerDisable" #if (!$host && !$port) checked="checked"#{end}/><span>&nbsp;$page.getLocalizedString("no.label")</span><br/>
+    <input type="radio" style="margin-left:1em;" id="loadBalancerEnable" #if ($host || $port) checked="checked"#{end}/><span>&nbsp;$page.getLocalizedString("yes.label")</span>
 
-    <div id="loadBalancerModule" style="width:500px;">
+    <div id="loadBalancerModule" style="width:100%;">
         <p id="allfields"><em>*</em>&nbsp;$page.getLocalizedString("required.field.label")</p>
         <b class="xtop"><b class="xt1"></b><b class="xt2"></b><b class="xt3"></b><b class="xt4"></b></b>
             <div class="headerBox">$page.getLocalizedString("step5.sub.title")</div>
-        <div class="bodyBox" style="height:180px">
+        <div class="bodyBox" style="max-height:330px;">
             $page.getLocalizedString("step5.help.message")
             <span>
                 <table class="temp">

--- a/openam-server-only/src/main/webapp/config/wizard/step6.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step6.htm
@@ -28,15 +28,15 @@
     YAHOO.util.Event.onDOMReady(initStep6);
 </script>
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("agent.step.title")<img class="pointer" src="$context/assets/images/message.gif"/></h1>
     <p>$page.getLocalizedString("agent.step.description")</p>
     
-    <div class="summaryPanel" style="width:570px">
+    <div class="summaryPanel" style="width:100%;">
         <p id="allfields"><em>*</em>&nbsp;$page.getLocalizedString("required.field.label")</p>
         <b class="xtop"><b class="xt1"></b><b class="xt2"></b><b class="xt3"></b><b class="xt4"></b></b>
         <div class="headerBox">$page.getLocalizedString("agent.step.subtitle")</div>
-        <div class="bodyBox"  style="height:180px">
+        <div class="bodyBox" style="max-height:350px;">
             <span>
                 <table class="temp">
                     <tr>

--- a/openam-server-only/src/main/webapp/config/wizard/step7.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/step7.htm
@@ -1,10 +1,10 @@
 
 
-<div style="margin-left:10px;">
+<div style="margin-left:10px;margin-bottom:10px;">
     <h1>$page.getLocalizedString("summary.title")</h1>
     <p>$page.getLocalizedString("summary.description")</p>
     
-    <div class="summaryPanel" style="width:570px">
+    <div class="summaryPanel" style="width:100%;">
         <b class="xtop">
             <b class="xt1"></b>
             <b class="xt2"></b>
@@ -12,7 +12,7 @@
             <b class="xt4"></b>
         </b>
         <div class="headerBox">$page.getLocalizedString("summary.title")</div>
-        <div class="bodyBox" style="height:340px">
+        <div class="bodyBox" style="max-height:380px;">
             <span>
                 <b>$page.getLocalizedString("step3.sub.title")</b>
                 <a href="#" onclick="showTab(3); return false;">$page.getLocalizedString("edit.label")</a>

--- a/openam-server-only/src/main/webapp/config/wizard/wizard.htm
+++ b/openam-server-only/src/main/webapp/config/wizard/wizard.htm
@@ -385,14 +385,16 @@
                         </ol>
                         &nbsp;
                     </div>
-                    <div id="tabContents" class="tabContents">
-                        <div id="wizardStep1" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep2" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep3" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep4" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep5" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep6" class="tabContent" style="display:none"></div>
-                        <div id="wizardStep7" class="tabContent" style="display:none"></div>
+                    <div class="scroll">
+                        <div id="tabContents" class="tabContents">
+                            <div id="wizardStep1" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep2" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep3" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep4" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep5" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep6" class="tabContent" style="display:none"></div>
+                            <div id="wizardStep7" class="tabContent" style="display:none"></div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
<!--
Provide an outline of this pull request in English, in the Title above.
上のタイトル欄に、プルリクエストの概要を *英語で* 記入してください。

Please be sure to write the title in the following format.
タイトルは以下の形式で記述してください。

Issue #<Issue id> <Outline of this pull request>
-->

## Analysis
<!--
Provide the root cause of the pull request.
問題の根本原因を記載してください。
-->
Although Layout depends on a browser, the height and the width of the boxes in the setup tool was inappropriately set fixed.

## Solution
<!--
Provide the solution.
解決策を記載してください。
-->
* Set the maximum height of the boxes. 
   * When the required size of the boxes is higher than the reference height, users can scroll the display.
   * When not, the height is automatically adjusted.
* Set fixed the appropriate width.
* Performed the fine adjustment.

## Testing
<!--
Provide the necessary test procedures to confirm the modification.
修正を確認するために必要なテスト手順を記載してください。
-->
1. If you have already finished configuring the initial setting, delete or move that data.
2. Access to OpenAM.