### PR TITLE
Issue #195 Tab UI selection is not highlighted on some screens

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/tab/TabComponentTemplate.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/tab/TabComponentTemplate.html
@@ -2,7 +2,7 @@
     <ul class="nav nav-tabs" role="tablist">
         {{#each tabs}}
             <li>
-                <a href="#" data-tab-id="{{this.id}}" role="tab" data-toggle="tab" aria-expanded="false">{{this.title}}</a>
+                <a href="#{{this.id}}" data-tab-id="{{this.id}}" role="tab" data-toggle="tab" aria-expanded="false">{{this.title}}</a>
             </li>
         {{/each}}
     </ul>


### PR DESCRIPTION
## Analysis

#195 

When clicking Tab UI, if the fragment of link url is an empty, an error will occur in JavaScript.
As a result, the selected tab is not highlighted.

I think it may be the effect of changing bootstarp at #135.


## Solution

Give tab id string to fragment of link url.
(Any string is okay if it is not an empty string)


## Testing

- See #195 Description
  - CONFIGURE > SERVER DEFAULTS
  - CONFIGURE > AUTHENTICATION > Core Attributes
  - DEPLOYMENT > SERVERS > (Select a server)

- See JavaScript console of the developer tool of the web browser

