### PR TITLE
Issue #197 Update THIRDPARTYREADME.txt for 14 release

### DIFF
--- a/legal/THIRDPARTYREADME.txt
+++ b/legal/THIRDPARTYREADME.txt
@@ -13,8 +13,20 @@ Copyright: Copyright © 2016, Amazon Web Services, Inc. or its affiliates. All r
 Version: aws-java-sdk-sqs-1.10.72.jar
 Copyright: Copyright © 2016, Amazon Web Services, Inc. or its affiliates. All rights reserved.
 
-Version: jackson-dataformat-cbor-2.5.3.jar
-Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
+Version: batik-constants-1.10.jar
+Copyright: Copyright 1999-2018 The Apache Software Foundation
+
+Version: batik-css-1.10.jar
+Copyright: Copyright 1999-2018 The Apache Software Foundation
+
+Version: batik-i18n-1.10.jar
+Copyright: Copyright 1999-2018 The Apache Software Foundation
+
+Version: batik-util-1.10.jar
+Copyright: Copyright 1999-2018 The Apache Software Foundation
+
+Version: bsh-2.0b6.jar
+Copyright: Copyright 1997-2012 Patrick Niemeyer
 
 Version: bootstrap-tabdrop-1.0.js
 Copyright: Copyright 2012 Stefan Petre
@@ -55,12 +67,18 @@ Copyright: Copyright (c) 2005-2009 Thomas Fuchs,
            (c) 2005-2009 Sam Stephenson,
            Copyright (c) 2005-2009 Marty Haught
 
+Version: commons-beanutils-1.9.3.jar
+Copyright: Copyright 2000-2016 The Apache Software Foundation
+
 Version: commons-codec-1.6.jar
 Copyright: Copyright 2002-2013 The Apache Software Foundation,
            Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
 
 Version: commons-collections-3.2.2.jar
 Copyright: Copyright 2001-2015 The Apache Software Foundation
+
+Version: commons-configuration-1.10.jar
+Copyright: Copyright 2001-2013 The Apache Software Foundation
 
 Version: commons-fileupload-1.3.3.jar
 Copyright: Copyright 2002-2017 The Apache Software Foundation
@@ -125,50 +143,53 @@ Copyright: Copyright 2003-2010 Terracotta, Inc.
 Version: FastInfoset-1.2.13.jar
 Copyright: Copyright (c) 2012-2013 Oracle and/or its affiliates. All rights reserved.
 
-Version: forgerock-guava-annotations-18.0.3.jar
+Version: forgerock-guava-annotations-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-base-18.0.3.jar
+Version: forgerock-guava-base-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-cache-18.0.3.jar
+Version: forgerock-guava-cache-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-collect-18.0.3.jar
+Version: forgerock-guava-collect-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-concurrent-18.0.3.jar
+Version: forgerock-guava-concurrent-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-escape-18.0.3.jar
+Version: forgerock-guava-escape-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-eventbus-18.0.3.jar
+Version: forgerock-guava-eventbus-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-hash-18.0.3.jar
+Version: forgerock-guava-hash-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-io-18.0.3.jar
+Version: forgerock-guava-io-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-math-18.0.3.jar
+Version: forgerock-guava-math-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-net-18.0.3.jar
+Version: forgerock-guava-net-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-primitives-18.0.3.jar
+Version: forgerock-guava-primitives-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guava-reflect-18.0.3.jar
+Version: forgerock-guava-reflect-18.0.5.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guice-core-1.1.0.jar
+Version: forgerock-guice-core-1.1.1.jar
 Copyright: Copyright 2010 The Guava Authors
 
-Version: forgerock-guice-servlet-1.1.0.jar
+Version: forgerock-guice-servlet-1.1.1.jar
 Copyright: Copyright 2010 The Guava Authors
+
+Version: freemarker-2.3.21.jar
+Copyright: Copyright 2014 Attila Szegedi, Daniel Dekany, Jonathan Revusky
 
 Version: geoip2-2.0.0.jar
 Copyright: Copyright https://www.maxmind.com
@@ -210,14 +231,8 @@ Copyright: Copyright (C) 2013-2015 Brett Wooldridge
 Version: httpasyncclient-4.1.jar
 Copyright: Copyright 2010-2015 The Apache Software Foundation
 
-Version: httpclient-4.0.1.jar
-Copyright: Copyright 1999-2014 The Apache Software Foundation
-
 Version: httpclient-4.4.1.jar
 Copyright: Copyright 1999-2015 The Apache Software Foundation
-
-Version: httpcore-4.0.1.jar
-Copyright: Copyright 1999-2014 The Apache Software Foundation
 
 Version: httpcore-4.4.1.jar
 Copyright: Copyright 2005-2015 The Apache Software Foundation
@@ -233,13 +248,13 @@ Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 Version: jackson-core-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-core-asl-1.9.7.jar
-Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
-
 Version: jackson-databind-2.9.7.jar
 Copyright: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: jackson-dataformat-csv-2.6.3.jar
+Version: jackson-dataformat-cbor-2.9.7.jar
+Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
+
+Version: jackson-dataformat-csv-2.9.7.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: jackson-dataformat-smile-2.4.4.jar
@@ -251,10 +266,10 @@ Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless othe
 Version: jackson-dataformat-yaml-2.4.4.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-module-jaxb-annotations-2.6.3.jar
+Version: jackson-module-jaxb-annotations-2.9.7.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
-Version: jackson-module-jsonSchema-2.6.3.jar
+Version: jackson-module-jsonSchema-2.9.7.jar
 Copyright: Copyright ©2009-2011 FasterXML, LLC. All rights reserved unless otherwise indicated.
 
 Version: java-ipv6-0.14.jar
@@ -281,8 +296,8 @@ Copyright: Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
 Version: jetty-util-8.1.15.v20140411.jar
 Copyright: Copyright (c) 1995-2015 Mort Bay Consulting Pty. Ltd.
 
-Version: joda-time-2.1.jar
-Copyright: Copyright 2001-2011 Stephen Colebourne
+Version: joda-time-2.7.jar
+Copyright: Copyright 2001-2014 Stephen Colebourne
 
 Version: jsr305-3.0.0.jar
 Copyright: Copyright (C) 2005, University of Maryland
@@ -290,6 +305,9 @@ Copyright: Copyright (C) 2005, University of Maryland
 
 Version: jstl-1.1.2.jar
 Copyright: Copyright 1999-2004 The Apache Software Foundation.
+
+Version: kerby-asn1-2.0.0.jar
+Copyright: Copyright 2014-2019 The Apache Software Foundation
 
 Version: log4j-1.2.16.jar
 Copyright: Copyright 2007 The Apache Software Foundation
@@ -299,6 +317,9 @@ Copyright: Copyright (c) 2014 by MaxMind, Inc.
 
 Version: neethi-3.0.3.jar
 Copyright: Copyright © 2004-2014 The Apache Software Foundation. All Rights Reserved.
+
+Version: nekohtml-1.9.22.jar
+Copyright: Copyright 2002-2009 Andy Clark, Marc Guillemot
 
 Version: opensaml-2.6.1.jar
 Copyright: Copyright (c) University Corporation for Advanced Internet Development, Inc.
@@ -334,14 +355,20 @@ Copyright: Copyright 2005-2012 Restlet S.A.S.
 Version: serializer-2.7.1.jar
 Copyright: Copyright 2001, 2002,2004 The Apache Software Foundation.
 
-Version: snakeyaml-1.6.jar
-Copyright: Copyright (c) 2008-2010 Andrey Somov
+Version: snakeyaml-1.13.jar
+Copyright: Copyright (c) 2008-2013, http://www.snakeyaml.org
 
 Version: super-csv-2.4.0.jar
 Copyright: Copyright 2007 Kasper B. Graversen
 
 Version: velocity-1.7.jar
 Copyright: Copyright 2005-2012 Restlet S.A.S.
+
+Version: webauthn4j-core-0.9.14.RELEASE.jar
+Copyright: Copyright 2002-2018 the original author or authors.
+
+Version: webauthn4j-util-0.9.14.RELEASE.jar
+Copyright: Copyright 2002-2018 the original author or authors.
 
 Version: xalan-2.7.1.jar
 Copyright: Copyright 1999-2006- Apache 1999-2002 - Lotus 2001-2002 - Sun, 2003 - IBM
@@ -360,6 +387,9 @@ Copyright: Copyright 2006 The Apache Software Foundation.
 
 Version: xml-serializer-2.11.0.jar
 Copyright: Copyright 1999-2006- Apache 1999-2002 - Lotus 2001-2002 - Sun, 2003 - IBM
+
+Version: xmlgraphics-commons-2.2.jar
+Copyright: Copyright 2006-2017 The Apache Software Foundation
 
 Version: xmlschema-core-2.1.0.jar
 Copyright: Copyright 2004-2014 The Apache Software Foundation
@@ -380,14 +410,11 @@ Copyright: Copyright 2009-2012, Red Hat, Inc. and/or its affiliates, and individ
 Version: woodstox-core-asl-4.3.0.jar
 Copyright (c) 2004 Tatu Saloranta, tatu.saloranta@iki.fi
 
-Version: woodstox-core-asl-4.4.1.jar
+Version: woodstox-core-5.0.3.jar
 Copyright (c) 2004 Tatu Saloranta, tatu.saloranta@iki.fi
 
 Version: wss4j-1.6.19.jar
 Copyright: Copyright 2004-2015 The Apache Software Foundation
-
-Version: joda-time-2.7.jar
-Copyright 2001-2016 Stephen Colebourne
 
 ==================
 Full license text:
@@ -469,6 +496,10 @@ limitations under the License.
 The BSD 3-Clause License
 ***************************************************************************
 
+Version: antisamy-1.5.7.jar
+Copyright: Copyright (c) 2007-2011, Arshan Dabirsiaghi, Jason Li
+           Copyright (c) 2013, Kristian Rosenvold
+
 Version: asm-3.3.1.jar
 Copyright: Copyright (c) 2000-2011 INRIA, France Telecom
 
@@ -478,23 +509,14 @@ Copyright: Copyright (c) 2010-2014, Christian Johansen
 Version: YUI toolkit (installer)
 Copyright: Copyright (c) 2007, Yahoo! Inc. All rights reserved.
 
-Version: esapiport-2013-12-04.jar
+Version: esapi-2.1.0.1.jar
 Copyright: Copyright (c) 2007 - The OWASP Foundation
-
-Version: freemarker-2.3.19.jar
-Copyright: Copyright (c) 2003 The Visigoth Software Society. All rights reserved.
 
 Version: ognl-2.6.9.jar
 Copyright: Copyright (c) 1998-2004, Drew Davidson and Luke Blanshard
 
 Version: relaxngDatatype-20020414.jar
 Copyright: Copyright (c) 2001, Thai Open Source Software Center Ltd, James Clark, Kohsuke KAWAGUCHI
-
-Version: forgerock-util-1.3.5.jar
-Copyright: Copyright 2014 ForgeRock AS.,
-           Copyright © 2010 ApexIdentity Inc. All rights reserved.,
-           Copyright (c) 2004, Mikael Grev, MiG InfoCom AB.,
-           Copyright (c) 2006-2008 Sun Microsystems Inc. All Rights Reserved
 
 Version: jquery-sortable-0.9.12.js
 Copyright: Copyright (c) 2012 Jonas von Andrian
@@ -795,8 +817,8 @@ Copyright: Copyright (c) 2012 Jimmy Yuen Ho Wong
 Version: backgrid.min-0.3.5-min.js
 Copyright: Copyright (c) 2012 Jimmy Yuen Ho Wong
 
-Version: bootstrap-3.3.5-custom.js
-Copyright: Copyright (c) 2011-2015 Twitter, Inc
+Version: bootstrap-3.4.1-openam-jp.js
+Copyright: Copyright 2011-2019 Twitter, Inc.
 
 Version: bootstrap-clockpicker-0.0.7-0915edd-min.js
 CopyrightL Copyright (c) 2014 Wang Shenwei
@@ -811,15 +833,12 @@ Version: codemirror/addon/display/fullscreen.js
 Copyright: Copyright (C) 2014 by Marijn Haverbeke
 
 Version: codemirror/lib/codemirror.js
-Copyright: Copyright (C) 2014 by Marijn Haverbeke
+Copyright: Copyright (c) by Marijn Haverbeke and others
 
-Version: codemirror/mode/groovy/groovy.js
-Copyright: Copyright (C) 2014 by Marijn Haverbeke
+Version: dragula-3.6.7-min.js
+Copyright: Copyright © 2015-2016 Nicolas Bevacqua
 
-Version: codemirror/mode/javascript/javascript.js
-Copyright: Copyright (C) 2014 by Marijn Haverbeke
-
-Version: form2js-2.0.js
+Version: form2js-2.0-769718a.js
 Copyright: Copyright (c) 2010 Maxim Vasiliev
 
 Version: handlebars-4.0.5.js
@@ -865,7 +884,7 @@ Copyright: Copyright 2012-2015 The Dojo Foundation
 Version: moment-2.8.1-min.js
 Copyright: Copyright Tim Wood, Iskren Chernev, Moment.js
 
-Version: qrcode-1.0.0-min.js
+Version: qrcode-1.4.3-min.js
 Copyright: Copyright (c) 2009 Kazuhiko Arase
 
 Version: qunit-1.15.0.js
@@ -919,7 +938,7 @@ Copyright: Copyright (c) 2013 Jeremy Dorn
 Version: jsoneditor-0.7.9-min.js
 Copyright: Copyright (c) 2013 Jeremy Dorn
 
-Version: js2form-2.0.js
+Version: js2form-2.0-769718a.js
 Copyright: Copyright (c) 2010 Maxim Vasiliev
 
 Version: require-jquery.js
@@ -931,20 +950,20 @@ Copyright: Copyright 2008 Sebo Zoltan <iamzoli@yahoo.com>
 Version: isorelax-20030108.jar
 Copyright: Copyright 2001 Kohsuke KAWAGUCHI
 
-Version: slf4j-api-1.7.5.jar
-Copyright: Copyright 2004-2013 QOS.ch
+Version: slf4j-api-1.7.12.jar
+Copyright: Copyright 2004-2011 QOS.ch
 
-Version: slf4j-nop-1.7.5.jar
-Copyright: Copyright 2004-2013 QOS.ch
+Version: slf4j-nop-1.7.12.jar
+Copyright: Copyright 2004-2011 QOS.ch
 
-Version: slf4j-jdk14-1.7.5.jar
-Copyright: Copyright 2004-2007 QOS.ch
+Version: slf4j-jdk14-1.7.12.jar
+Copyright: Copyright 2004-2011 QOS.ch
 
-Version: log4j-over-slf4j-1.7.5.jar
-Copyright: Copyright 2004-2013 QOS.ch
+Version: log4j-over-slf4j-1.7.12.jar
+Copyright: Copyright 2004-2011 QOS.ch
 
-Version: text.js
-Copyright: Copyright (c) 2010-2014, The Dojo Foundation
+Version: text-2.0.15.js
+Copyright: Copyright jQuery Foundation and other contributors.
 
 ==================
 Full license text:
@@ -1188,11 +1207,14 @@ Copyright: Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved
 Version: password.js
 Copyright: Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved
 
+Version: authz-framework-20.1.1.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: authz-framework-api-20.1.1.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
 Version: activation-1.1.jar
 Copyright: Copyright 1997-2007 Sun Microsystems, Inc. All rights reserved.
-
-Version: grizzly-framework-2.3.11.jar
-Copyright: Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
 
 Version: jato-2005-05-04.jar
 Copyright: Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved
@@ -1233,23 +1255,117 @@ Copyright: Copyright (c) 2008 Sun Microsystems Inc. All Rights Reserved
 Version: cc_zh_TW-2008-08-08.jar
 Copyright: Copyright (c) 2008 Sun Microsystems Inc. All Rights Reserved
 
-Version: grizzly-framework-2.3.23.jar
+Version: chf-client-apache-async-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+
+Version: chf-client-apache-common-20.1.1.jar
+Copyright: Copyright 2015 ForgeRock AS.
+
+Version: chf-client-apache-sync-20.1.1.jar
+Copyright: Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2010–2011 ApexIdentity Inc.
+           Portions Copyright 2011-2016 ForgeRock AS.
+
+Version: chf-http-core-20.1.1.jar
+Copyright: Copyright 2009 Sun Microsystems Inc.
+           Portions Copyright 2010–2011 ApexIdentity Inc.
+           Portions Copyright 2011-2016 ForgeRock AS.
+
+Version: chf-http-servlet-20.1.1.jar
+Copyright: Copyright 2010–2011 ApexIdentity Inc.
+           Portions Copyright 2011-2016 ForgeRock AS.
+
+Version: forgerock-audit-core-20.1.1.jar
+Copyright: Copyright 2006-2008 Sun Microsystems, Inc.
+           Copyright 2013 Cybernetica AS
+           Copyright 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-audit-handler-csv-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: forgerock-audit-handler-elasticsearch-20.1.1.jar
+Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-audit-handler-jdbc-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2016 Nomura Research Institute, Ltd.
+
+Version: forgerock-audit-handler-jms-20.1.1.jar
+Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-audit-handler-syslog-20.1.1.jar
+Copyright: Copyright 2013 Cybernetica AS
+           Copyright 2015-2016 ForgeRock AS.
+
+Version: forgerock-audit-json-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+
+Version: forgerock-bloomfilter-core-1.0.2.jar
+Copyright: Copyright (C) 2011 The Guava Authors
+           Copyright 2015 ForgeRock AS.
+
+Version: forgerock-bloomfilter-monitoring-1.0.2.jar
+Copyright: Copyright 2015 ForgeRock AS.
+
+Version: forgerock-jaspi-jwt-session-module-20.1.1.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-jaspi-openid-connect-module-20.1.1.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: forgerock-jaspi-runtime-20.1.1.jar
+Copyright: Copyright 2013-2015 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-persistit-core-4.3.2.jar
+Copyright: Copyright 2005-2012 Akiban Technologies, Inc.
+           Copyright 2015 ForgeRock AS
+
+Version: forgerock-selfservice-core-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: forgerock-selfservice-stages-20.1.1.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions copyright 2019 Open Source Solution Technology Corporation
+
+Version: forgerock-util-20.1.1.jar
+Copyright: Copyright 2010–2011 ApexIdentity Inc. All rights reserved.
+           Copyright 2011-2016 ForgeRock AS.
+
+Version: grizzly-framework-2.3.24.jar
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: grizzly-http-2.3.23.jar
+Version: grizzly-http-2.3.24.jar
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: grizzly-http-server-2.3.23.jar
+Version: grizzly-http-server-2.3.24.jar
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: grizzly-http-servlet-2.3.23.jar
+Version: grizzly-http-servlet-2.3.24.jar
 Copyright: Copyright (c) 2007-2015 Oracle and/or its affiliates. All rights reserved.
 
 Version: javax.jms:javax.jms-api:2.0.1.jar
 Copyright: Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights reserved.
 
-Version: jaxb-impl-1.0.6.jar
-Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
+Version: jaxb-api-2.3.0.jar
+Copyright: Copyright (c) 2003-2017 Oracle and/or its affiliates. All rights reserved.
+
+Version: jaxb-core-2.3.0.jar
+Copyright: Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
+
+Version: jaxb-impl-2.2.2.jar
+Copyright: Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+Version: jaxb1-impl-2.2.5.1.jar
+Copyright: Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
 
 Version: jaxb-xjc-1.0.6.jar
 Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
@@ -1257,11 +1373,17 @@ Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
 Version: jsp-api-2.1.jar
 Copyright: Copyright 2005 Sun Microsystems, Inc. All rights reserved.
 
-Version: jaxb-api-1.0.6.jar
-Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
+Version: javax.annotation-api-1.3.2.jar
+Copyright: Copyright (c) 2005-2018 Oracle and/or its affiliates. All rights reserved.
+
+Version: javax.mail-1.5.1.jar
+Copyright: Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
 
 Version: javax.security.auth.message-3.1.jar
 Copyright: Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+
+Version: javax.xml.soap-api-1.4.0.jar
+Copyright: Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
 
 Version: jaxb-libs-1.0.6.jar
 Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
@@ -1275,11 +1397,14 @@ Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights rese
 Version: jaxrpc-api-1.1.jar
 Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
 
-Version: jaxrpc-impl-1.1.3_01-041406.jar
+Version: jaxrpc-impl-1.1.3_01.jar
 Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
 
 Version: jaxrpc-spi-1.1.3_01.jar
 Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
+
+Version: jaxws-api-2.3.1.jar
+Copyright: Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
 
 Version: jdmkrt-2007-01-10.jar
 Copyright: Copyright (c) 2001-2011 Oracle and/or its affiliates. All rights reserved.
@@ -1293,29 +1418,20 @@ Copyright: Copyright 1997-2007 Sun Microsystems
 Version: jersey-core-1.1.5.2.jar
 Copyright: Copyright 1997-2007 Sun Microsystems, Inc. All rights reserved.
 
-Version: chf-http-core-1.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
-
-Version: chf-http-servlet-1.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
-
-Version: chf-client-apache-common-1.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
-
-Version: chf-client-apache-sync-1.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
-
 Version: json-fluent-3.0.0.jar
 Copyright: Copyright 2015 ForgeRock AS.
 
-Version: json-resource-3.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
+Version: json-resource-20.1.1.jar
+Copyright: Copyright 2012-2015 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 
-Version: json-resource-http-3.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
+Version: json-resource-http-20.1.1.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.
 
-Version: json-web-token-3.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.
+Version: json-web-token-20.1.1.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
 Version: jsr311-api-1.1.1.jar
 Copyright: Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
@@ -1332,16 +1448,10 @@ Copyright: Copyright 2009 Sun Microsystems, Inc. All rights reserved.
 Version: oauth-signature-1.1.5.2.jar
 Copyright: Copyright 2009 Sun Microsystems, Inc. All rights reserved.
 
-Version: opendj-ldap-sdk-2.6.9.jar
-Copyright: Copyright 2014 ForgeRock AS.
-
-Version: opendj-server-2.6.2.jar
-Copyright: Copyright 2014 ForgeRock AS.
-
 Version: xsdlib-20060615.jar
 Copyright: Copyright (c) 2001-2013 Oracle and/or its affiliates. All rights reserved.
 
-Version: ClientSDK-12.0.0.jar
+Version: ClientSDK-14.0.0.jar
 Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
            Copyright 2011-2014 ForgeRock AS.,
            Portions Copyrighted 2014 Nomura Research Institute, Ltd.,
@@ -1350,189 +1460,422 @@ Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
            Copyright © 2010 ApexIdentity Inc. All rights reserved.,
            Copyright (c) 2004, Mikael Grev, MiG InfoCom AB.
 
-Version: i18n-core-1.4.0.jar
+Version: i18n-core-1.4.3.jar
 Copyright: Copyright 2009 Sun Microsystems, Inc,
-           Portions copyright 2011 ForgeRock AS
+           Portions copyright 2011-2012 ForgeRock AS
 
-Version: i18n-core-1.4.1.jar
-Copyright: Copyright 2009 Sun Microsystems, Inc,
-           Portions copyright 2011 ForgeRock AS
+Version: i18n-slf4j-1.4.3.jar
+Copyright: Copyright 2011-2014 ForgeRock AS
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 
-Version: openam-auth-ad-12.0.0.jar
+Version: openam-annotations-14.0.0.jar
+Copyright: Copyright 2013-2015 ForgeRock AS.
+
+Version: openam-audit-configuration-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyright 2016 Nomura Research Institute, Ltd.
+
+Version: openam-audit-context-14.0.0.jar
+Copyright: Copyright 2015 ForgeRock AS.
+
+Version: openam-audit-core-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-audit-rest-14.0.0.jar
+Copyright: Copyright 2015 ForgeRock AS.
+
+Version: openam-auth-ad-14.0.0.jar
 Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-anonymous-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-application-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-cert-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-datastore-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-hotp-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
+           Portions Copyrighted 2011-2016 ForgeRock AS
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
            Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
-Version: openam-auth-httpbasic-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
+Version: openam-auth-adaptive-14.0.0.jar
+Copyright: Copyright 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2013-2016 Nomura Research Institute, Ltd.
 
-Version: openam-auth-jdbc-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
-           Copyrighted 2012 Open Source Solution Technology Corporation
-
-Version: openam-auth-ldap-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd
-
-Version: openam-auth-membership-12.0.0.jar
-Copyright: Copyright (c) 2011-2012 ForgeRock Inc. All Rights Reserved,
-           Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved
-
-Version: openam-auth-msisdn-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-nt-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-radius-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-scripted-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-securid-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-auth-windowsdesktopsso-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS
-
-Version: openam-common-auth-ui-12.0.0.jar
-Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS.,
-           Portions Copyrighted 2012 Open Source Solution Technology Corporation,
-           Portions Copyrighted 2013 Nomura Research Institute, Ltd.
-
-Version: openam-configurator-tool-12.0.0.jar
-Copyright: Copyright (c) 2008 Sun Microsystems, Inc. All Rights Reserved.,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
+Version: openam-auth-anonymous-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2015 ForgeRock AS
            Portions Copyrighted 2012 Open Source Solution Technology Corporation
 
-Version: openam-core-12.0.0.jar
-Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
-           Portions Copyrighted 2014 Nomura Research Institute Ltd.,
-           Portions Copyrighted 2012 Open Source Solution Technology Corporation,
-           Portions Copyrighted 2013 Cybernetica AS.
+Version: openam-auth-application-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS.
 
-Version: openam-coretoken-12.0.0.jar
-Copyright: Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+Version: openam-auth-cert-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
-Version: openam-entitlements-12.0.0.jar
-Copyright: Copyright (c) 2008-2009 Sun Microsystems Inc. All Rights Reserved,
-           Copyright 2011-2014 ForgeRock AS.
-
-Version: openam-example-clientsdk-cli-12.0.0.jar
-Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved
-
-Version: openam-federation-library-12.0.0.jar
-Copyright: Copyright (c) 2008-2009 Sun Microsystems Inc. All Rights Reserved,
-           Copyright 2011-2014 ForgeRock AS.,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
-
-Version: openam-idpdiscovery-12.0.0.jar
-Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2013 ForgeRock AS.
-
-Version: openam-server-auth-ui-12.0.0.jar
-Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved,
-           Portions Copyrighted 2011-2014 ForgeRock AS,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
-
-Version: OpenFM-12.0.0.jar
-Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved,
-           Copyright 2011-2013 ForgeRock AS.,
-           Portions Copyrighted 2012 Open Source Solution Technology Corporation,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
-
-Version: oauth2-core-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
-
-Version: openam-auth-adaptive-12.0.0.jar
-Copyright: Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved,
-           Portions Copyrighted 2013-2014 Nomura Research Institute, Ltd
-
-Version: openam-auth-common-12.0.0.jar
-Copyright: Copyright 2011-2014 ForgeRock AS.,
+Version: openam-auth-common-14.0.0.jar
+Copyright: Copyright 2011-2015 ForgeRock AS.,
            Portions Copyrighted 2011 Cybernetica AS.
 
-Version: openam-oauth-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
-
-Version: openam-auth-oath-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,Copyright (c) 2011 IETF Trust,
-           Portions Copyrighted 2014 Nomura Research Institute, Ltd,
-
-Version: openam-auth-oauth2-12.0.0.jar
-Copyright: Copyright 2011-2014 ForgeRock AS.,
-           Copyright 2011 Cybernetica AS.
-
-Version: openam-cli-definitions-12.0.0.jar
-Copyright: Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved,
-           Portions Copyrighted 2013-2014 Nomura Research Institute, Ltd
-
-Version: openam-cli-impl-12.0.0.jar
-Copyright: Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved,
-           Portions Copyrighted 2013-2014 Nomura Research Institute, Ltd
-
-Version: openam-installer-utils-12.0.0.jar
-Copyright: Copyright (c) 2011 ForgeRock AS. All Rights Reserved,
+Version: openam-auth-datastore-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS
            Portions Copyrighted 2012 Open Source Solution Technology Corporation
 
-Version: openam-upgrade-tool-12.0.0.jar
-Copyright: Portions Copyrighted 2012 Open Source Solution Technology Corporation
+Version: openam-auth-device-id-14.0.0.jar
+Copyright: Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+           Copyright 2011-2015 ForgeRock AS.
+           Copyright 2011 Cybernetica AS.
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2013 Nomura Research Institute, Ltd
 
-Version: openam-oauth2-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,
+Version: openam-auth-fr-oath-14.0.0.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.
+           Copyright (c) 2011 IETF Trust and the persons identified as authors of the code. All rights reserved.
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd.
+
+Version: openam-auth-hotp-14.0.0.jar
+Copyright: Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved,
+           Copyright (C) 2004, OATH.  All rights reserved.
+           Portions Copyrighted 2011-2016 ForgeRock AS,
+           Portions Copyrighted 2012-2014 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd
+
+Version: openam-auth-httpbasic-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2015 ForgeRock AS
+           Portions Copyrighted 2014 Open Source Solution Technology Corporation
            Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
-Version: openam-rest-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,
-           Copyright (c) 2006-2008 Sun Microsystems Inc.,
+Version: openam-auth-jdbc-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS,
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-auth-ldap-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2010-2016 ForgeRock AS,
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
            Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
-Version: openid-connect-restlet-12.0.0.jar
-Copyright: Copyright 2014 ForgeRock AS.,
+Version: openam-auth-membership-14.0.0.jar
+Copyright: Copyright (c) 2011-2015 ForgeRock AS. All Rights Reserved
+           Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-auth-msisdn-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS
+           Portions Copyrighted 2012-2014 Open Source Solution Technology Corporation
+           Portions Copyrighted 2013-2014 Nomura Research Institute, Ltd
+
+Version: openam-auth-nt-14.0.0.jar
+Copyright: Copyright (c) 2005-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2015 ForgeRock AS
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-auth-oath-14.0.0.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.
+           Copyright (c) 2011 IETF Trust and the persons identified as authors of the code. All rights reserved.
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014 Nomura Research Institute, Ltd,
+
+Version: openam-auth-oauth2-14.0.0.jar
+Copyright: Copyright 2011-2016 ForgeRock AS.,
+           Copyright 2011 Cybernetica AS.
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2013-2015 Nomura Research Institute, Ltd.
+
+Version: openam-auth-oidc-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+           Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-auth-persistentcookie-14.0.0.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.
+           Portions Copyrighted 2014-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014 Nomura Research Institute, Ltd
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-auth-push-14.0.0.jar
+Copyright: Copyright 2016 ForgeRock AS.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-auth-radius-14.0.0.jar
+Copyright: Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+           Portions Copyrighted 2015 Intellectual Reserve, Inc (IRI)
+
+Version: openam-auth-saml2-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-auth-scripted-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved,
+           Copyright 2014-2016 ForgeRock AS.
+           Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-auth-webauthn-14.0.0.jar
+Copyright: Copyright 2019 Open Source Solution Technology Corporation
+
+Version: openam-auth-windowsdesktopsso-14.0.0.jar
+Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+
+Version: openam-certs-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2010-2016 ForgeRock AS
+
+Version: openam-cli-definitions-14.0.0.jar
+Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2010-2016 ForgeRock AS.
            Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
-Version: forgerock-util-2.0.0.jar
-Copyright: Copyright 2015 ForgeRock AS.,
-           Copyright © 2010 ApexIdentity Inc. All rights reserved.,
-           Copyright (c) 2004, Mikael Grev, MiG InfoCom AB.,
-           Copyright (c) 2006-2008 Sun Microsystems Inc. All Rights Reserved
+Version: openam-cli-impl-14.0.0.jar
+Copyright: Copyright (c) 2006-2009 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2010-2016 ForgeRock AS.
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+           Portions Copyrighted 2013-2014 Nomura Research Institute, Ltd
 
-Version: javax.mail-1.5.1.jar
-Copyright: Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+Version: openam-client-sts-14.0.0.jar
+Copyright: Copyright 2013-2016 ForgeRock AS. All rights reserved.
+
+Version: openam-common-auth-ui-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS.,
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation,
+           Portions Copyrighted 2013-2015 Nomura Research Institute, Ltd.
+
+Version: openam-common-sts-14.0.0.jar
+Copyright: Copyright 2013-2015 ForgeRock AS. All rights reserved.
+
+Version: openam-configurator-tool-14.0.0.jar
+Copyright: Copyright (c) 2008 Sun Microsystems, Inc. All Rights Reserved.,
+           Portions Copyrighted 2011-2015 ForgeRock AS,
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-core-14.0.0.jar
+Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2016 ForgeRock AS,
+           Portions Copyrighted 2013-2015 Nomura Research Institute Ltd.,
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation,
+           Portions Copyrighted 2013 Cybernetica AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-core-rest-14.0.0.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.
+           Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd
+           Portions Copyrighted 2018-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-coretoken-14.0.0.jar
+Copyright: Copyright (c) 2009 Sun Microsystems Inc. All Rights Reserved
+
+Version: openam-dashboard-14.0.0.jar
+Copyright: Copyright (c) 2012-2015 ForgeRock AS.
+           Portions Copyrighted 2016 Nomura Research Institute, Ltd.
+
+Version: openam-datastore-14.0.0.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.
+           Portions Copyright 2016 Nomura Research Institute, Ltd.
+
+Version: openam-dtd-schema-14.0.0.jar
+Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2010-2016 ForgeRock AS.
+           Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd
+
+Version: openam-entitlements-14.0.0.jar
+Copyright: Copyright (c) 2006-2009 Sun Microsystems Inc. All Rights Reserved,
+           Copyright 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014-2015 Nomura Research Institute, Ltd.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-federation-library-14.0.0.jar
+Copyright: Copyright (c) 2006-2009 Sun Microsystems Inc. All Rights Reserved,
+           Copyright 2010-2016 ForgeRock AS.,
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-http-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+
+Version: openam-http-client-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: openam-idpdiscovery-14.0.0.jar
+Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2013-2016 ForgeRock AS.
+
+Version: openam-idsvcs-schema-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved
+
+Version: openam-installer-utils-14.0.0.jar
+Copyright: Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved,
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-jaxrpc-schema-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved
+
+Version: openam-ldap-utils-14.0.0.jar
+Copyright: Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved
+           Copyright 2013-2016 ForgeRock AS.
+
+Version: openam-liberty-schema-14.0.0.jar
+Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
+
+Version: openam-license-core-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: openam-license-manager-cli-14.0.0.jar
+Copyright: Copyright 2014-2015 ForgeRock AS.
+
+Version: openam-license-servlet-14.0.0.jar
+Copyright: Copyright 2014-2015 ForgeRock AS.
+
+Version: openam-mib-schema-14.0.0.jar
+Copyright: Copyright (c) 2009, Sun Microsystems, All Rights Reserved.
+           Copyright 2013-2015 ForgeRock AS.
+
+Version: openam-oauth2-14.0.0.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.,
+           Portions Copyrighted 2013-2015 Nomura Research Institute, Ltd
+           Portions Copyrighted 2014-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-oauth2-saml2-14.0.0.jar
+Copyright: Copyright 2012-2016 ForgeRock AS.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-publish-sts-14.0.0.jar
+Copyright: Copyright 2014-2015 ForgeRock AS.
+
+Version: openam-push-notification-14.0.0.jar
+Copyright: Copyright 2014-2015 ForgeRock AS.
+
+Version: openam-radius-common-14.0.0.jar
+Copyright: Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2011-2015 ForgeRock AS
+           Portions Copyrighted 2015 Intellectual Reserve, Inc (IRI)
+
+Version: openam-radius-server-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Copyright 2015 Intellectual Reserve, Inc (IRI)
+
+Version: openam-rest-14.0.0.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.,
+           Copyright (c) 2008-2009 Sun Microsystems Inc.,
+           Portions Copyrighted 2014 Nomura Research Institute, Ltd
+           Portions Copyrighted 2014-2019 Open Source Solution Technology Corporation
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-rest-sts-14.0.0.jar
+Copyright: Copyright 2013-2016 ForgeRock AS.
+
+Version: openam-restlet-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: openam-saml2-schema-14.0.0.jar
+Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
+           Portions Copyrighted 2010 ForgeRock AS
+
+Version: openam-scripting-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-selfservice-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2018 Open Source Solution Technology Corporation
+
+Version: openam-server-auth-ui-14.0.0.jar
+Copyright: Copyright (c) 2005 Sun Microsystems Inc. All Rights Reserved,
+           Portions Copyrighted 2011-2014 ForgeRock AS,
+           Portions Copyrighted 2014 Nomura Research Institute, Ltd.
+
+Version: openam-shared-14.0.0.jar
+Copyright: Copyright (c) 2005-2009 Sun Microsystems Inc. All Rights Reserved
+           Copyright 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-slf4j-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: openam-token-service-sts-14.0.0.jar
+Copyright: Copyright 2014-2016 ForgeRock AS.
+
+Version: openam-tokens-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+
+Version: openam-uma-14.0.0.jar
+Copyright: Copyright 2015-2016 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: openam-upgrade-tool-14.0.0.jar
+Copyright: Copyright (c) 2011-2014 ForgeRock AS. All Rights Reserved
+           Portions Copyrighted 2012 Open Source Solution Technology Corporation
+
+Version: openam-upgrade-14.0.0.jar
+Copyright: Copyright (c) 2011-2016 ForgeRock AS.
+           Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyrighted 2019 Open Source Solution Technology Corporation
+
+Version: openam-wsfederation-schema-14.0.0.jar
+Copyright: Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
+
+Version: openam-xacml3-schema-14.0.0.jar
+Copyright: Copyright (c) 2011-2013 ForgeRock AS. All Rights Reserved
+
+Version: OpenFM-14.0.0.jar
+Copyright: Copyright (c) 2006-2007 Sun Microsystems Inc. All Rights Reserved,
+           Copyright 2011-2016 ForgeRock AS.,
+           Portions Copyrighted 2012-2019 Open Source Solution Technology Corporation,
+           Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd.
+
+Version: opendj-cli-3.0.1.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Copyright 2011-2015 ForgeRock AS.
+
+Version: opendj-config-3.0.1.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Portions Copyright 2011-2015 ForgeRock AS.
+
+Version: opendj-core-3.0.1.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Copyright 2011-2015 ForgeRock AS
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyright 2019 Open Source Solution Technology Corporation
+
+Version: opendj-grizzly-3.0.1.jar
+Copyright: Copyright 2009-2010 Sun Microsystems, Inc.
+           Copyright 2011-2015 ForgeRock AS.
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+           Portions Copyright 2019 Open Source Solution Technology Corporation
+
+Version: opendj-je-backend.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Portions Copyright 2010-2015 ForgeRock AS.
+
+Version: opendj-rest2ldap-3.0.1.jar
+Copyright: Copyright 2012-2015 ForgeRock AS.
+
+Version: opendj-server-3.0.1.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Copyright 2013-2015 ForgeRock AS.
+
+Version: opendj-server-legacy-3.0.1.jar
+Copyright: Copyright 2006-2010 Sun Microsystems, Inc.
+           Portions Copyright 2011-2015 ForgeRock AS
+           Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+
+Version: quicksetup.jar
+Copyright: Copyright 2006-2009 Sun Microsystems, Inc.
+           Portions Copyright 2011-2015 ForgeRock AS
 
 ==================
 Full license text:
@@ -1675,6 +2018,9 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 
 Version: mimepull-1.7.jar
 Copyright: Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+
+Version: saaj-api-1.3.4.jar
+Copyright: Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
 
 Version: saaj-impl-1.3.19.jar
 Copyright: Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
@@ -1916,3 +2262,157 @@ The above copyright notice and this permission notice shall be included in all c
 The Software shall be used for Good, not Evil.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+***************************************************************************
+GNU Lesser General Public License, Version 2.1
+***************************************************************************
+
+Version: xom-1.2.10.jar
+Copyright: Copyright 2002-2013 Elliotte Rusty Harold
+
+==================
+Full license text:
+==================
+
+GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+    b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+    c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+    d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+    a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+    b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+    c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+    d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+    e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+    b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. 
+


### PR DESCRIPTION
## Analysis

THIRDPARTYREADME.txt contains the library license, but it seems to be out of date.

## Solution

* Update version / copyright information in THIRDPARTYREADME.txt
* Add libraries used by OpenAM, if they does not exist in THIRDPARTYREADME.txt