### PR TITLE
Issue #199 Policy with day of the week in Japanese does not work

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrDayView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrDayView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 
@@ -25,7 +26,7 @@ define([
         i18n: {
             "weekdays": { "key": "console.authorization.common.weekdays.", "full": ".full", "short": ".short" }
         },
-        days: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+        days: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
 
         render (data, element, callback) {
             this.initBasic(data, element, "pull-left attr-group");
@@ -43,7 +44,7 @@ define([
             _.invoke(self.days, function () {
                 weekdays[i] = {};
                 weekdays[i].title = $.t(self.i18n.weekdays.key + this + self.i18n.weekdays.full);
-                weekdays[i].value = $.t(self.i18n.weekdays.key + this + self.i18n.weekdays.short);
+                weekdays[i].value = this;
                 i++;
             });
             return weekdays;

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditEnvironmentView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditEnvironmentView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -117,6 +118,9 @@ define([
                         if (key === "type") {
                             itemToDisplay["console.common.type"] = $.t(self.i18n.condition.key + type +
                                 self.i18n.condition.title);
+                        } else if (type === "SimpleTime" && (key === "startDay" || key === "endDay")) {
+                            itemToDisplay[self.i18n.condition.key + type + self.i18n.condition.props + key] =
+                                $.t(`console.authorization.common.weekdays.${val}.short`);
                         } else {
                             itemToDisplay[self.i18n.condition.key + type + self.i18n.condition.props + key] = val;
                         }

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/en/translation.json
@@ -1046,31 +1046,31 @@
                 "noItems": "There are no items ...",
 
                 "weekdays": {
-                    "Monday": {
+                    "mon": {
                         "short": "mon",
                         "full": "Monday"
                     },
-                    "Tuesday": {
+                    "tue": {
                         "short": "tue",
                         "full": "Tuesday"
                     },
-                    "Wednesday": {
+                    "wed": {
                         "short": "wed",
                         "full": "Wednesday"
                     },
-                    "Thursday": {
+                    "thu": {
                         "short": "thu",
                         "full": "Thursday"
                     },
-                    "Friday": {
+                    "fri": {
                         "short": "fri",
                         "full": "Friday"
                     },
-                    "Saturday": {
+                    "sat": {
                         "short": "sat",
                         "full": "Saturday"
                     },
-                    "Sunday": {
+                    "sun": {
                         "short": "sun",
                         "full": "Sunday"
                     }

--- a/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
+++ b/openam-ui/openam-ui-ria/src/main/resources/locales/ja/translation.json
@@ -1046,31 +1046,31 @@
                 "noItems": "アイテムがありません...",
 
                 "weekdays": {
-                    "Monday": {
+                    "mon": {
                         "short": "月",
                         "full": "月曜日"
                     },
-                    "Tuesday": {
+                    "tue": {
                         "short": "火",
                         "full": "火曜日"
                     },
-                    "Wednesday": {
+                    "wed": {
                         "short": "水",
                         "full": "水曜日"
                     },
-                    "Thursday": {
+                    "thu": {
                         "short": "木",
                         "full": "木曜日"
                     },
-                    "Friday": {
+                    "fri": {
                         "short": "金",
                         "full": "金曜日"
                     },
-                    "Saturday": {
+                    "sat": {
                         "short": "土",
                         "full": "土曜日"
                     },
-                    "Sunday": {
+                    "sun": {
                         "short": "日",
                         "full": "日曜日"
                     }


### PR DESCRIPTION
## Analysis

The time policy condition uses the translation.json value as the setting data for the day of the week (for example, `console.authorization.common.weekdays.Monday.short`). Therefore, time policy conditions may not work as expected if the browser language setting is other than English.

translation.json is information for localization and should not be used as a setting value.

## Solution

Define the values for week settings in the JavaScript file. And change the display process for the time policy condition.

## Testing

Try #199 "Steps to reproduce", and works as "Expected Results".