### PR TITLE
Issue #211 Memory leak: LDAPFilterCondition creates new ShutdownManager listener on each request

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
@@ -575,15 +575,6 @@ public class LDAPFilterCondition implements Condition {
         LDAPConnectionPools.initConnectionPool(ldapServer, authid, authpw, sslEnabled, minPoolSize, maxPoolSize,
                 options);
         connPool = LDAPConnectionPools.getConnectionPool(ldapServer);
-        ShutdownManager shutdownMan = com.sun.identity.common.ShutdownManager.getInstance();
-        shutdownMan.addShutdownListener(
-                new ShutdownListener() {
-                    public void shutdown() {
-                        if (connPool != null) {
-                            connPool.close();
-                        }
-                    }
-                });
 
         policyConfigExpiresAt = currentTimeMillis() + getSubjectsResultTtl(configParams);
     }

--- a/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
@@ -25,6 +25,7 @@
  * $Id: LDAPFilterCondition.java,v 1.8 2009/11/20 23:52:55 ww203982 Exp $
  *
  * Portions Copyrighted 2010-2016 ForgeRock AS.
+ * Portions Copyrighted 2020 OGIS-RI Co., Ltd.
  */
 
 package com.sun.identity.policy.plugins;

--- a/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/plugins/LDAPFilterCondition.java
@@ -37,7 +37,6 @@ import static org.forgerock.opendj.ldap.LDAPConnectionFactory.CONNECT_TIMEOUT;
 import com.iplanet.sso.SSOException;
 import com.iplanet.sso.SSOToken;
 import com.iplanet.sso.SSOTokenListenersUnsupportedException;
-import com.sun.identity.common.ShutdownManager;
 import com.sun.identity.policy.ConditionDecision;
 import com.sun.identity.policy.PolicyConfig;
 import com.sun.identity.policy.PolicyEvaluator;
@@ -75,7 +74,6 @@ import org.forgerock.opendj.ldap.requests.SearchRequest;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
 import org.forgerock.util.Options;
-import org.forgerock.util.thread.listener.ShutdownListener;
 import org.forgerock.util.time.Duration;
 
 /**


### PR DESCRIPTION
## Analysis

See #211 and https://bugster.forgerock.org/jira/browse/OPENAM-12037

The `LDAPFilterCondition.java#setPolicyConfig` method in the LDAPFilterCondition adds a new ShutdownListener each time it is called (if cache is disabled or expired), although only one ShutdownListener is needed.


## Solution

The code to adds a new ShutdownListener exists in two places and is redundant.

1. `com.sun.identity.policy.plugins$LDAPFilterCondition.java#setPolicyConfig`
2. `com.sun.identity.policy.plugins$LDAPConnectionPools#initConnectionPool`

Therefore, remove 1.


## Performance

Heap usage is significantly reduced in load tests.
In the case of 1,000 accesses per second for 30 minutes, the heap usage before the fix was about 621MB, but after the fix the heap usage improved to 226MB.


## Testing

- Load test (1,000 accesses per second for 30 minutes)
- Verified that the connection pool is properly disconnected and reconnected (Shut down the LDAP during the load test and restarted it after 1 minute)
