### PR TITLE
Issue #219 Upgrade Jackson library to 2.10.x

### DIFF
--- a/openam-authentication/openam-auth-hotp/pom.xml
+++ b/openam-authentication/openam-auth-hotp/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
     </dependencies>
 

--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -375,7 +375,7 @@
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-distribution/openam-distribution-diagnostics/pom.xml
+++ b/openam-distribution/openam-distribution-diagnostics/pom.xml
@@ -89,8 +89,8 @@
             <artifactId>openam-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/openam-distribution/openam-distribution-diagnostics/src/main/assembly/openAMDiagnosticAssembly_Descriptor.xml
+++ b/openam-distribution/openam-distribution-diagnostics/src/main/assembly/openAMDiagnosticAssembly_Descriptor.xml
@@ -22,7 +22,7 @@
 * your own identifying information:
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
-* Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -42,7 +42,7 @@
                 <include>jp.openam:openam-diagnostics-schema</include>
                 <include>jp.openam:openam-core</include>
                 <include>jp.openam:openam-shared</include>
-                <include>javax.xml.bind:jaxb-api</include>
+                <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
                 <include>com.sun.xml.bind:jaxb-impl</include>
                 <include>com.sun.msv.datatype.xsd:xsdlib</include>
                 <include>external:webservices-rt</include>

--- a/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/ResourceAttributeUtilTest.java
+++ b/openam-entitlements/src/test/java/com/sun/identity/entitlement/xacml3/ResourceAttributeUtilTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2020 Open Source Solution Technology Corporation
  */
 package com.sun.identity.entitlement.xacml3;
 
@@ -54,7 +55,7 @@ public class ResourceAttributeUtilTest {
     public void shouldCatchFailureIfDeserialisationFails() throws IOException {
         // Given
         ObjectMapper mockMapper = mock(ObjectMapper.class);
-        given(mockMapper.readValue(anyString(), any(Class.class))).willThrow(new IOException());
+        given(mockMapper.readValue(anyString(), any(Class.class))).willThrow(new IllegalArgumentException());
         util = new ResourceAttributeUtil(mockMapper);
 
         // When / Then

--- a/openam-schema/openam-diagnostics-schema/pom.xml
+++ b/openam-schema/openam-diagnostics-schema/pom.xml
@@ -104,8 +104,8 @@
             <artifactId>openam-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/openam-schema/openam-idsvcs-schema/pom.xml
+++ b/openam-schema/openam-idsvcs-schema/pom.xml
@@ -144,8 +144,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-idsvcs-schema/pom.xml
+++ b/openam-schema/openam-idsvcs-schema/pom.xml
@@ -175,7 +175,7 @@
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-jaxrpc-schema/pom.xml
+++ b/openam-schema/openam-jaxrpc-schema/pom.xml
@@ -158,8 +158,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-liberty-schema/pom.xml
+++ b/openam-schema/openam-liberty-schema/pom.xml
@@ -118,8 +118,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-saml2-schema/pom.xml
+++ b/openam-schema/openam-saml2-schema/pom.xml
@@ -113,8 +113,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-wsfederation-schema/pom.xml
+++ b/openam-schema/openam-wsfederation-schema/pom.xml
@@ -100,8 +100,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-xacml3-schema/pom.xml
+++ b/openam-schema/openam-xacml3-schema/pom.xml
@@ -124,8 +124,8 @@
             <artifactId>jaxb-libs</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION

## Analysis

#219

Newer version of Jackson depend on some Jakarta EE library. And these conflict with the libraries included in this project.

* jakarta.xml.bind-api-2.3.2.jar vs jaxb-api-2.3.0.jar
* jakarta.activation-api-1.2.1.jar vs activation-1.1.jar

But javax.mail depend on Java EE activation. We need to change javax.mail too.

## Solution

* jaxb-api -> jakarta.xml.bind-api
* activation-> jakarta.activation
* javax.mail -> jakarta.mail

## Testing

Unit tests works fine.