### PR TITLE
Issue #224 ServiceConfigImpl causes memory leak

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/sm/ServiceConfigImpl.java
+++ b/openam-core/src/main/java/com/sun/identity/sm/ServiceConfigImpl.java
@@ -25,7 +25,7 @@
  * $Id: ServiceConfigImpl.java,v 1.15 2008/10/14 04:57:20 arviranga Exp $
  *
  * Portions Copyrighted 2012-2016 ForgeRock AS.
- * Portions Copyrighted 2012 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2012-2020 Open Source Solution Technology Corporation
  */
 
 package com.sun.identity.sm;
@@ -620,8 +620,6 @@ class ServiceConfigImpl implements ServiceListener {
             if (!answer.isValid()) {
                 configImpls.remove(cn, answer);
                 answer.clear();
-                answer = null;
-            } else if (answer.smsEntry.isNewEntry()) {
                 answer = null;
             }
         }


### PR DESCRIPTION
## Analysis
A new instance may be created even if a ServiceConfigImpl instance already exists in the cache.
ServiceConfigImpl instance of cache is not released, resulting in memory leak.

## Solution
Uses the cache unless the ServiceConfigImpl instance is invalid.

* F.Y.I
The fix that frees the cache for the ServiceConfigImpl instance in the specific case that caused it and creates a new one does not work(see https://bugster.forgerock.org/jira/browse/OPENAM-5542)

## Performance
I tested using the SAML2 authentication module.
Before the fix, 5000 logins generated about 10000 ServiceConfigImpl instances. 
After the fix, it was confirmed that many ServiceConfigImpl instances were not created even with 5000 logins.

## Testing
Testing with SAML2 authentication module

