### PR TITLE
Issue #255 styles-admin.less fails to compile because codemirror.css cannot be found

### DIFF
--- a/openam-ui/openam-ui-ria/pom.xml
+++ b/openam-ui/openam-ui-ria/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <codemirror.version>4.10.0</codemirror.version>
+        <codemirror.version>4.10</codemirror.version>
         <handlebars.version>4.0.5</handlebars.version>
         <node.install.directory>${project.basedir}</node.install.directory>
     </properties>
@@ -104,7 +104,7 @@
         </dependency>
         <dependency>
             <groupId>jp.openam.commons.ui.libs</groupId>
-            <artifactId>CodeMirror</artifactId>
+            <artifactId>codemirror5</artifactId>
             <version>${codemirror.version}</version>
             <type>zip</type>
         </dependency>
@@ -249,7 +249,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>jp.openam.commons.ui.libs</groupId>
-                                    <artifactId>CodeMirror</artifactId>
+                                    <artifactId>codemirror5</artifactId>
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>

--- a/openam-ui/openam-ui-ria/src/main/assembly/dir.xml
+++ b/openam-ui/openam-ui-ria/src/main/assembly/dir.xml
@@ -13,7 +13,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Portions copyright 2011-2015 ForgeRock AS.
-* Portions Copyrighted 2019 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019-2022 OSSTech Corporation
   -->
 <assembly
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
@@ -26,7 +26,7 @@
     </formats>
     <fileSets>
         <fileSet>
-            <directory>${project.build.directory}/CodeMirror-${codemirror.version}</directory>
+            <directory>${project.build.directory}/codemirror-${codemirror.version}</directory>
             <outputDirectory>/libs/codemirror</outputDirectory>
             <includes>
                 <include>lib/codemirror.js</include>
@@ -36,7 +36,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/CodeMirror-${codemirror.version}</directory>
+            <directory>${project.build.directory}/codemirror-${codemirror.version}</directory>
             <outputDirectory>/css/codemirror</outputDirectory>
             <includes>
                 <include>lib/codemirror.css</include>
@@ -50,7 +50,7 @@
                 <include>jp.openam.commons.ui.libs:*:js</include>
             </includes>
             <excludes>
-                <exclude>jp.openam.commons.ui.libs:CodeMirror</exclude>
+                <exclude>jp.openam.commons.ui.libs:codemirror5</exclude>
             </excludes>
             <outputDirectory>/libs</outputDirectory>
         </dependencySet>


### PR DESCRIPTION
## Analysis

`forgerock-ui-external-libs` has a process to download `CodeMirror` and install it in the Maven local repository.
So the cause is that the downloaded file has changed.

## Solution

`forgerock-ui-external-libs` installs the new `CodeMirror` archive as a new artifact on Maven.
Then the build process of OpenAM will use the new artifacts.

## Testing

I have confirmed that the OpenAM build is successful with openam-jp/forgerock-ui#18.