### PR TITLE
Issue #271 Update Restlet Maven repository

### DIFF
--- a/.github/workflows/build_and_release_openam_nightly.yml
+++ b/.github/workflows/build_and_release_openam_nightly.yml
@@ -62,7 +62,6 @@ jobs:
           fi
           if [ "${REPO}" == 'openam' ]; then
             sed -ie "s|<url>http://download.oracle.com|<url>https://download.oracle.com|g" openam/openam-core/pom.xml
-            find ./openam -type f -name 'pom.xml' | xargs sed -ie "s|<url>http://maven.restlet.com|<url>https://maven.restlet.com|g"
           fi
           #----------------------------------------
 

--- a/openam-http-client/pom.xml
+++ b/openam-http-client/pom.xml
@@ -13,7 +13,7 @@ Header, with the fields enclosed by brackets [] replaced by your own identifying
 information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014-2015 ForgeRock AS.
-Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+Portions Copyrighted 2019-2022 OSSTech Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -61,7 +61,7 @@ Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-oauth2-saml2/pom.xml
+++ b/openam-oauth2-saml2/pom.xml
@@ -51,7 +51,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-oauth2/pom.xml
+++ b/openam-oauth2/pom.xml
@@ -23,7 +23,7 @@
   ~ your own identifying information:
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
-  ~ Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019-2022 OSSTech Corporation
   ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
@@ -219,7 +219,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-rest/pom.xml
+++ b/openam-rest/pom.xml
@@ -22,7 +22,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2022 OSSTech Corporation
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -244,7 +244,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-restlet/pom.xml
+++ b/openam-restlet/pom.xml
@@ -22,7 +22,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2022 OSSTech Corporation
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -195,7 +195,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
+++ b/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
@@ -14,7 +14,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2022 OSSTech Corporation
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   -->
 
@@ -159,7 +159,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/openam-uma/pom.xml
+++ b/openam-uma/pom.xml
@@ -22,7 +22,7 @@
 * your own identifying information:
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
-* Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019-2022 OSSTech Corporation
 * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -103,7 +103,7 @@
         <repository>
             <id>restlet-repository</id>
             <name>Restlet Repository</name>
-            <url>http://maven.restlet.com</url>
+            <url>https://maven.restlet.talend.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
## Analysis

See #271

## Solution

Use `https://maven.restlet.talend.com` as Restlet Maven repository

## Testing

* Build OpenAM
* Make sure that `org.restlet*.jar` hashes match that before the fix