### PR TITLE
#288 Fix release page status for Nightly Build

### DIFF
--- a/.github/workflows/build_and_release_openam_nightly.yml
+++ b/.github/workflows/build_and_release_openam_nightly.yml
@@ -165,6 +165,37 @@ jobs:
           console.log(`Created release '${RELEASE_NAME}': ${result.data.id}`);
           return `${result.data.id}`;
 
+    - name: Update the release page status
+      id: update_release_status
+      if: ${{ steps.create_release.outcome == 'success' }}
+      uses: actions/github-script@v6.3.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}          
+        result-encoding: string
+        script: |
+          /*
+           * Create the 'nightly' release.
+           *   - Using 'github-script' because 'create-release' action is no longer maintained.
+           *   - Set the following attributes: Name, CDDL-license, pre-release indication.
+           *   - Output release id. (Usage: "${{ steps.create_release.outputs.result }}")
+           */
+          const { owner, repo } = context.repo;
+          const releaseId = `${{ steps.create_release.outputs.result }}`;
+
+          const result = await github.rest.repos.updateRelease({
+            owner: owner,
+            repo: repo,
+            release_id: releaseId,
+            draft: false,
+            prerelease: true,
+          }).catch((e) => {
+            core.setFailed(`Cannot update release page '${RELEASE_NAME}': ${e}`);
+          })
+          console.log(`result.data.draft : ${result.data.draft}`);
+          console.log(`result.data.prerelease : ${result.data.prerelease}`);
+          // Pass release ID to next step.
+          return `${result.data.id}`;
+
     - name: Upload artifacts
       id: upload_artifacts
       if: ${{ steps.create_release.outcome == 'success' }}

--- a/.github/workflows/build_and_release_openam_nightly.yml
+++ b/.github/workflows/build_and_release_openam_nightly.yml
@@ -174,10 +174,10 @@ jobs:
         result-encoding: string
         script: |
           /*
-           * Create the 'nightly' release.
-           *   - Using 'github-script' because 'create-release' action is no longer maintained.
-           *   - Set the following attributes: Name, CDDL-license, pre-release indication.
-           *   - Output release id. (Usage: "${{ steps.create_release.outputs.result }}")
+           * Update the 'nightly' release page status.
+           *   - Using 'github-script'.
+           *   - Set the following attributes: draft, prerelease.
+           *   - Output release id. (Usage: "${{ steps.update_release_status.outputs.result }}")
            */
           const { owner, repo } = context.repo;
           const releaseId = `${{ steps.create_release.outputs.result }}`;


### PR DESCRIPTION
## Analysis
It turns out that if a Release or Tag already exists, when Actions creates a Release, the status of the Release changes to `Draft`.

## Solution
After Actions creates the Release, perform an Update to ensure the status is `Draft`.
