### PR TITLE
Issue #291 OpenDJ version checks are inconsistent

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/upgrade/OpenDJUpgrader.java
+++ b/openam-core/src/main/java/org/forgerock/openam/upgrade/OpenDJUpgrader.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2023 OSSTech Corporation
  */
 
 package org.forgerock.openam.upgrade;
@@ -157,8 +159,7 @@ public class OpenDJUpgrader {
      * @return {@code true} if an upgrade should be performed.
      */
     public boolean isUpgradeRequired() {
-        return newVersion.isMoreRecentThan(currentVersion) ||
-                (newVersion.equals(currentVersion) && newVersion.isDifferentBuildTo(currentVersion));
+        return newVersion.isMoreRecentThan(currentVersion);
     }
 
     /**


### PR DESCRIPTION
## Analysis

See #291

## Solution

Ignore the buildRevision in OpenDJ version check.

## Testing

I performed the following tests with openam-jp/opendj#13 .

* Upgrade with OpenAM including new `buildRevision` OpenDJ
    * OpenDJ upgrade will be skipped
* Upgrade form 14.0.0 to 15.0.0-SNAPSHOT
    * OpenDJ upgrade succeeds