### PR TITLE
Issue #293 build the latest tag when tagged (re-opened)

### DIFF
--- a/.github/workflows/build_and_release_openam_when_tagged.yml
+++ b/.github/workflows/build_and_release_openam_when_tagged.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -54,11 +55,13 @@ jobs:
 
           #----------------------------------------
           # Get the commit hash of the latest tag of all branches, and get the name of the newest tag there, excluding nightly
-          latest_tag=refs/tags/$(git -C ${REPO} describe --tags --exclude nightly `git -C ${REPO} rev-list --tags --max-count=1`)
           #----------------------------------------
-
-          git -C ${REPO} checkout -b ${latest_tag}
+          latest_tag=$(git -C ${REPO} describe --tags --exclude nightly `git -C ${REPO} rev-list --tags --max-count=1`)
+          git -C ${REPO} checkout -b ${latest_tag} refs/tags/${latest_tag}
         done
+
+        # Get the release name from tag
+        echo "RELEASE_NAME=${latest_tag}" >> "$GITHUB_ENV"
 
         for REPO in ${REPO_NAMES}; do
           #----------------------------------------
@@ -78,11 +81,6 @@ jobs:
             exit 1;
           fi
         done
-
-    - name: Get the version
-      id: extract_version
-      run: |
-        echo "RELEASE_NAME=$(echo $GITHUB_REF | cut -d / -f 3)" >> "$GITHUB_ENV"
 
     - name: Create the release
       id: create_release


### PR DESCRIPTION
## Solution
merge #296 (cherry-picked)
* Fixed the code to be built is as intended latest tag
* Added workflow_dispatch event to trigger to kicked from Actions
* Release name uses tag name instead of branch name
