### PR TITLE
Issue #300 Nightly Build fails in openam-ui-ria

### DIFF
--- a/.github/workflows/build_and_release_openam_nightly.yml
+++ b/.github/workflows/build_and_release_openam_nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     strategy:

--- a/.github/workflows/build_and_release_openam_when_tagged.yml
+++ b/.github/workflows/build_and_release_openam_when_tagged.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     strategy:


### PR DESCRIPTION
## Analysis

Nightly Build workflow uses `ubuntu-latest` image. This image has changed from `22.04` to `24.04`.

Due to this major version upgrade, Chrome cannot enable the sandbox.

## Solution

Fix Ubuntu version to 22.04.

## Testing

Run workflow from GUI.
