### PR TITLE
Issue #302 Build fails with Maven 3.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 * your own identifying information:
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
-* Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+* Portions Copyrighted 2019-2025 OSSTech Corporation
 * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 *
 -->
@@ -1408,7 +1408,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>net.ju-n.maven.plugins</groupId>


### PR DESCRIPTION
## Analysis

#302

## Solution

Bump maven-shade-plugin version to 3.6.0.

For this purpose, refer to maven-shade-plugin version in forgerock-parent.