### PR TITLE
Issue #222 ws & federationrest servlet initialization fails

### DIFF
--- a/legal/THIRDPARTYREADME.txt
+++ b/legal/THIRDPARTYREADME.txt
@@ -1358,9 +1358,6 @@ Copyright: Copyright (c) 2012-2015 Oracle and/or its affiliates. All rights rese
 Version: jaxb-api-2.3.0.jar
 Copyright: Copyright (c) 2003-2017 Oracle and/or its affiliates. All rights reserved.
 
-Version: jaxb-core-2.3.0.jar
-Copyright: Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
-
 Version: jaxb-impl-2.2.2.jar
 Copyright: Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
 

--- a/openam-schema/openam-liberty-schema/pom.xml
+++ b/openam-schema/openam-liberty-schema/pom.xml
@@ -22,7 +22,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2026 OSSTech Corporation
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -130,11 +130,6 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-schema/openam-wsfederation-schema/pom.xml
+++ b/openam-schema/openam-wsfederation-schema/pom.xml
@@ -22,7 +22,7 @@
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  *
- * Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+ * Portions Copyrighted 2019-2026 OSSTech Corporation
  * Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -112,11 +112,6 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Analysis

The cause is that classes are conflicting between jaxb-impl-2.2.2.jar and jaxb-core-2.3.0.jar.

## Solution

Remove jaxb-core dependency.

## Testing

* jaxb-core.jar is not included in OpenAM.war
* The target servlets are running
* No errors are output to localhost.log