### PR TITLE
Issue #309 Limits do not work in LDAP filter condition

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/policy/PolicyConfig.java
+++ b/openam-core/src/main/java/com/sun/identity/policy/PolicyConfig.java
@@ -25,6 +25,7 @@
  * $Id: PolicyConfig.java,v 1.10 2009/01/28 05:35:01 ww203982 Exp $
  *
  * Portions Copyright 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 OSSTech Corporation
  */
 
 package com.sun.identity.policy;
@@ -130,6 +131,9 @@ public class PolicyConfig implements com.sun.identity.sm.ServiceListener {
     
     public static final String LDAP_SEARCH_LIMIT =
         "iplanet-am-policy-config-search-limit";
+
+    public static final String LDAP_CONNECTION_TIME_OUT =
+        "iplanet-am-policy-config-connection_time_out";
 
     public static final String LDAP_CONNECTION_POOL_MIN_SIZE =
         "iplanet-am-policy-config-connection_pool_min_size";

--- a/openam-core/src/main/resources/amPolicyConfig.properties
+++ b/openam-core/src/main/resources/amPolicyConfig.properties
@@ -26,7 +26,7 @@
 #
 
 # Portions Copyrighted 2012-2014 ForgeRock, AS.
-# Portions Copyrighted 2012 Open Source Solution Technology Corporation
+# Portions Copyrighted 2012-2026 OSSTech Corporation
 
 onlinehelp.doc=policyattr.html
 iplanet-am-policy-config-service-description=Policy Configuration
@@ -162,3 +162,6 @@ a162=SampleReferral
 a163=SampleResponseProvider
 
 a144=Web Services Clients
+
+connectionTimeout=LDAP Connection Timeout
+connectionTimeout.help=In milliseconds.

--- a/openam-core/src/main/resources/ja_JP/amPolicyConfig_ja.properties
+++ b/openam-core/src/main/resources/ja_JP/amPolicyConfig_ja.properties
@@ -26,7 +26,7 @@
 #
 
 # Portions Copyrighted 2012 ForgeRock Inc
-# Portions Copyrighted 2012 Open Source Solution Technology Corporation
+# Portions Copyrighted 2012-2026 OSSTech Corporation
 
 
 onlinehelp.doc=policyattr.html
@@ -159,4 +159,5 @@ a161=SampleCondition
 a162=SampleReferral
 a163=SampleResponseProvider
 
-
+connectionTimeout=LDAP \u30b3\u30cd\u30af\u30b7\u30e7\u30f3\u30bf\u30a4\u30e0\u30a2\u30a6\u30c8
+connectionTimeout.help=(\u30df\u30ea\u79d2)

--- a/openam-server-only/src/main/resources/services/amPolicyConfig.xml
+++ b/openam-server-only/src/main/resources/services/amPolicyConfig.xml
@@ -27,6 +27,7 @@
     $Id: amPolicyConfig.xml,v 1.9 2009/05/05 18:53:03 mrudul_uchil Exp $
 
     Portions Copyrighted 2014-2015 ForgeRock AS.
+    Portions Copyrighted 2026 OSSTech Corporation
 -->
 
 <!DOCTYPE ServicesConfiguration
@@ -358,6 +359,16 @@
                     resourceName="connectionPoolMaximumSize">
                     <DefaultValues>
                         <Value>10</Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="iplanet-am-policy-config-connection_time_out"
+                    type="single"
+                    syntax="number"
+                    i18nKey="connectionTimeout"
+                    order="1850"
+                    resourceName="connectionTimeout">
+                    <DefaultValues>
+                        <Value>10000</Value>
                     </DefaultValues>
                 </AttributeSchema>
                 <AttributeSchema name="iplanet-am-policy-selected-subjects"


### PR DESCRIPTION
## Analysis

See #309

## Solution

* Use `Maximum Results Returned from Search` and `Search Timeout` correctly
* Add a parameter for the connection timeout