### PR TITLE
Issue #320 Single Logout does not work in the SAML2 authentication module

### DIFF
--- a/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2PostAuthenticationPlugin.java
+++ b/openam-authentication/openam-auth-saml2/src/main/java/org/forgerock/openam/authentication/modules/saml2/SAML2PostAuthenticationPlugin.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 package org.forgerock.openam.authentication.modules.saml2;
 
@@ -59,8 +60,6 @@ import org.forgerock.guice.core.InjectorHolder;
 import org.forgerock.openam.federation.saml2.SAML2TokenRepositoryException;
 import org.forgerock.openam.saml2.SAML2Store;
 import org.forgerock.openam.xui.XUIState;
-import org.owasp.esapi.ESAPI;
-import org.owasp.esapi.errors.EncodingException;
 
 /**
  * Plugin that gets activated for SLO for the SAML2 auth module. Supports HTTP-Redirect
@@ -246,17 +245,12 @@ public class SAML2PostAuthenticationPlugin implements AMPostAuthProcessInterface
         try {
             final String ssOutEnabled = ssoToken.getProperty(SAML2Constants.SINGLE_LOGOUT);
             if (Boolean.parseBoolean(ssOutEnabled)) {
-                final XUIState xuiState = InjectorHolder.getInstance(XUIState.class);
                 final StringBuilder logoutLocation = new StringBuilder();
                 logoutLocation.append(ssoToken.getProperty(SLO_SESSION_LOCATION));
-                if (xuiState.isXUIEnabled()) {
-                    logoutLocation.append(ESAPI.encoder().encodeForURL(ssoToken.getProperty(SLO_SESSION_REFERENCE)));
-                } else {
-                    logoutLocation.append(ssoToken.getProperty(SLO_SESSION_REFERENCE));
-                }
+                logoutLocation.append(ssoToken.getProperty(SLO_SESSION_REFERENCE));
                 request.setAttribute(AMPostAuthProcessInterface.POST_PROCESS_LOGOUT_URL, logoutLocation.toString());
             }
-        } catch (EncodingException | SSOException e) {
+        } catch (SSOException e) {
             //debug warning and fall through
             DEBUG.warning("Error loading SAML assertion information in memory. SLO failed for this session.", e);
         }

--- a/openam-core/src/main/resources/ESAPI.properties
+++ b/openam-core/src/main/resources/ESAPI.properties
@@ -6,6 +6,7 @@
 # http://www.owasp.org/index.php/ESAPI.
 #
 # Copyright (c) 2008,2009 - The OWASP Foundation
+# Portions copyright 2026 OSSTech Corporation
 #
 # DISCUSS: This may cause a major backwards compatibility issue, etc. but
 #		   from a name space perspective, we probably should have prefaced
@@ -495,3 +496,6 @@ Validator.DirectoryName=^[a-zA-Z0-9:/\\\\!@#$%^&{}\\[\\]()_+\\-=,.~'` ]{1,255}$
 # Validation of dates. Controls whether or not 'lenient' dates are accepted.
 # See DataFormat.setLenient(boolean flag) for further details.
 Validator.AcceptLenientDates=false
+
+# Validation of RelayState
+Validator.RelayState=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ %]*$

--- a/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutInit.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutInit.jsp
@@ -25,6 +25,7 @@
    $Id: idpSingleLogoutInit.jsp,v 1.9 2009/10/15 00:00:41 exu Exp $
 
    Portions Copyrighted 2010-2014 ForgeRock AS
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 
@@ -76,7 +77,7 @@
         if ((relayState == null) || (relayState.length() == 0)) {
             relayState = request.getParameter(SAML2Constants.GOTO);
         }
-        if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "HTTPQueryString", 2000, true)) {
+        if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "URL", 2000, true)) {
             relayState = null;
         }
         Object ssoToken = null;
@@ -92,8 +93,7 @@
                } 
                response.sendRedirect(intermmediatePage);
             } else {
-                if (relayState != null && SAML2Utils.isRelayStateURLValid(request, relayState, SAML2Constants.IDP_ROLE) &&
-                    ESAPI.validator().isValidInput("RelayState", relayState, "URL", 2000, true)) {
+                if (relayState != null && SAML2Utils.isRelayStateURLValid(request, relayState, SAML2Constants.IDP_ROLE)) {
                    response.sendRedirect(relayState);
                } else {
                    %>
@@ -117,8 +117,7 @@
         }
         if (metaAlias == null) {
             SessionManager.getProvider().invalidateSession(ssoToken, request, response);
-            if (relayState != null && SAML2Utils.isRelayStateURLValid(request, relayState, SAML2Constants.IDP_ROLE)
-                    && ESAPI.validator().isValidInput("RelayState", relayState, "URL", 2000, true)) {
+            if (relayState != null && SAML2Utils.isRelayStateURLValid(request, relayState, SAML2Constants.IDP_ROLE)) {
                 response.sendRedirect(relayState);
             } else {
                 %>
@@ -182,8 +181,7 @@
         IDPSingleLogout.initiateLogoutRequest(request,response, new PrintWriter(out, true),
             binding,paramsMap);
         if (!response.isCommitted()) {
-            if (relayState != null && SAML2Utils.isRelayStateURLValid(metaAlias, relayState, SAML2Constants.IDP_ROLE)
-                    && ESAPI.validator().isValidInput("RelayState", relayState, "URL", 2000, true)) {
+            if (relayState != null && SAML2Utils.isRelayStateURLValid(metaAlias, relayState, SAML2Constants.IDP_ROLE)) {
                 response.sendRedirect(relayState);
             } else {
                 %>

--- a/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutPOST.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutPOST.jsp
@@ -25,6 +25,7 @@
    $Id: idpSingleLogoutPOST.jsp,v 1.5 2009/06/24 23:05:30 mrudulahg Exp $
 
    Portions Copyrighted 2013 ForgeRock AS
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 <%@ page import="com.sun.identity.saml.common.SAMLUtils" %>
@@ -62,17 +63,17 @@
     //- SAMLResponse - the LogoutResponse
 
     String relayState = request.getParameter(SAML2Constants.RELAY_STATE);
-    if (relayState != null) {
-        String tmpRs = (String) IDPCache.relayStateCache.remove(relayState);
-        if (tmpRs != null) {
-            relayState = tmpRs;
-        }
-    }
-    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "HTTPQueryString", 2000, true)) {
+    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "RelayState", 2000, true)) {
         relayState = null;
     }
     String samlResponse = request.getParameter(SAML2Constants.SAML_RESPONSE);
     if (samlResponse != null) {
+        if (relayState != null) {
+            String tmpRs = (String) IDPCache.relayStateCache.remove(relayState);
+            if (tmpRs != null) {
+                relayState = tmpRs;
+            }
+        }
         boolean doRelayState = true;
         try {
         /**

--- a/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutRedirect.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/idpSingleLogoutRedirect.jsp
@@ -25,6 +25,7 @@
    $Id: idpSingleLogoutRedirect.jsp,v 1.9 2009/06/12 22:21:42 mallas Exp $
 
    Portions Copyrighted 2013 ForgeRock AS
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 
@@ -69,17 +70,17 @@
     //- SAMLResponse - the LogoutResponse
 
     String relayState = request.getParameter(SAML2Constants.RELAY_STATE);
-    if (relayState != null) {
-        String tmpRs = (String) IDPCache.relayStateCache.remove(relayState);
-        if (tmpRs != null) {
-            relayState = tmpRs;
-        }
-    }
-    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "HTTPQueryString", 2000, true)) {
+    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "RelayState", 2000, true)) {
         relayState = null;
     }
     String samlResponse = request.getParameter(SAML2Constants.SAML_RESPONSE);
     if (samlResponse != null) {
+        if (relayState != null) {
+            String tmpRs = (String) IDPCache.relayStateCache.remove(relayState);
+            if (tmpRs != null) {
+                relayState = tmpRs;
+            }
+        }
         boolean doRelayState = true;
         try {
         /**

--- a/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutInit.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutInit.jsp
@@ -25,6 +25,7 @@
    $Id: spSingleLogoutInit.jsp,v 1.13 2009/10/15 00:01:11 exu Exp $
 
    Portions Copyrighted 2012-2016 ForgeRock AS.
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 <%@ page import="com.sun.identity.plugin.session.SessionManager" %>
@@ -94,7 +95,7 @@
         if (RelayState == null || RelayState.isEmpty()) {
             RelayState = request.getParameter(SAML2Constants.GOTO);
         }
-        if (!ESAPI.validator().isValidInput("RelayState", RelayState, "HTTPQueryString", 2000, true)) {
+        if (!ESAPI.validator().isValidInput("RelayState", RelayState, "URL", 2000, true)) {
             RelayState = null;
         }
 
@@ -118,8 +119,7 @@
                 //There is no local session, so we can't perform the logout on the IdP,
                 //let's just return with HTTP 200
                 if (RelayState != null && !RelayState.isEmpty()
-                        && SAML2Utils.isRelayStateURLValid(request, RelayState, SAML2Constants.SP_ROLE)
-                        && ESAPI.validator().isValidInput("RelayState", RelayState, "URL", 2000, true)) {
+                        && SAML2Utils.isRelayStateURLValid(request, RelayState, SAML2Constants.SP_ROLE)) {
                     saml2Auditor.auditAccessSuccess();
                     response.sendRedirect(RelayState);
                 } else {
@@ -163,8 +163,7 @@
                     SAML2Utils.debug.message("No session.");
                 }
             }
-            if (RelayState != null && SAML2Utils.isRelayStateURLValid(request, RelayState, SAML2Constants.SP_ROLE)
-                    && ESAPI.validator().isValidInput("RelayState", RelayState, "URL", 2000, true)) {
+            if (RelayState != null && SAML2Utils.isRelayStateURLValid(request, RelayState, SAML2Constants.SP_ROLE)) {
                 saml2Auditor.auditAccessSuccess();
                 response.sendRedirect(RelayState);
             } else {
@@ -269,8 +268,7 @@
 
         if (binding.equalsIgnoreCase(SAML2Constants.SOAP)) {
             if (RelayState != null && !RelayState.isEmpty()
-                    && SAML2Utils.isRelayStateURLValid(metaAlias, RelayState, SAML2Constants.SP_ROLE)
-                    && ESAPI.validator().isValidInput("RelayState", RelayState, "URL", 2000, true)) {
+                    && SAML2Utils.isRelayStateURLValid(metaAlias, RelayState, SAML2Constants.SP_ROLE)) {
                 response.sendRedirect(RelayState);
             } else {
                 %>

--- a/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutPOST.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutPOST.jsp
@@ -25,6 +25,7 @@
    $Id: spSingleLogoutPOST.jsp,v 1.8 2009/06/24 23:05:31 mrudulahg Exp $
 
    Portions Copyrighted 2013-2015 ForgeRock AS.
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 
@@ -75,18 +76,18 @@
     //- SAMLResponse - the LogoutResponse
 
     String relayState = request.getParameter(SAML2Constants.RELAY_STATE);
-    if (relayState != null) {
-        CacheObject tmpRs= 
-            (CacheObject) SPCache.relayStateHash.remove(relayState);
-        if ((tmpRs != null)) {
-            relayState = (String) tmpRs.getObject();
-        }
-    }
-    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "HTTPQueryString", 2000, true)) {
+    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "RelayState", 2000, true)) {
         relayState = null;
     }
     String samlResponse = request.getParameter(SAML2Constants.SAML_RESPONSE);
     if (samlResponse != null) {
+        if (relayState != null) {
+            CacheObject tmpRs=
+                (CacheObject) SPCache.relayStateHash.remove(relayState);
+            if ((tmpRs != null)) {
+                relayState = (String) tmpRs.getObject();
+            }
+        }
         try {
         /**
          * Gets and processes the Single <code>LogoutResponse</code> from IDP,

--- a/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutRedirect.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/spSingleLogoutRedirect.jsp
@@ -25,6 +25,7 @@
    $Id: spSingleLogoutRedirect.jsp,v 1.14 2009/06/17 03:10:28 exu Exp $
 
    Portions Copyrighted 2013-2015 ForgeRock AS.
+   Portions Copyrighted 2019-2026 OSSTech Corporation
 --%>
 
 <%@ page import="com.sun.identity.sae.api.SecureAttrs" %>
@@ -81,18 +82,18 @@
     //- SAMLResponse - the LogoutResponse
 
     String relayState = request.getParameter(SAML2Constants.RELAY_STATE);
-    if (relayState != null) {
-        CacheObject tmpRs= 
-            (CacheObject) SPCache.relayStateHash.remove(relayState);
-        if ((tmpRs != null)) {
-            relayState = (String) tmpRs.getObject();
-        }
-    }
-    if (!ESAPI.validator().isValidInput("HTTP Query String: " + relayState, relayState, "HTTPQueryString", 2000, true)) {
+    if (!ESAPI.validator().isValidInput("HTTP URL Value: " + relayState, relayState, "RelayState", 2000, true)) {
         relayState = null;
     }
     String samlResponse = request.getParameter(SAML2Constants.SAML_RESPONSE);
     if (samlResponse != null) {
+        if (relayState != null) {
+            CacheObject tmpRs=
+            (CacheObject) SPCache.relayStateHash.remove(relayState);
+            if ((tmpRs != null)) {
+                relayState = (String) tmpRs.getObject();
+            }
+        }
         boolean sloFailed = false;
         try {
         /**


### PR DESCRIPTION
## Analysis

See #320

## Solution

* Fix encoding process when generating the location for SAML2 Single Logout
* Review of SAML2 parameter validation process using ESAPI

## Testing

Single Logout URL in the SAML2 authentication module works fine.