### PR TITLE
Issue #332 Support manual device registration in ForgeRock Authenticator (OATH) authentication

### DIFF
--- a/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH.properties
+++ b/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH.properties
@@ -11,7 +11,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2012-2015 ForgeRock AS.
-# Portions Copyrighted 2019 Open Source Solution Technology Corporation
+# Portions copyright 2019-2026 OSSTech Corporation
 
 authentication=Authentication Modules
 iPlanetAMAuthAuthenticatorOATHServiceDescription=ForgeRock Authenticator (OATH)
@@ -63,3 +63,7 @@ authFailed=Authentication Failed
 outOfSync=Device has exceeded maximum clock drift. Please re-register your device.
 login_header=OATH Authenticator
 otpcodemiss=Invalid OTP code. You will be requested to start again after {0} more failure(s).
+register_otp_algorithm_hotp=Counter-based
+register_otp_algorithm_totp=Time-based
+register_otp_manual_message=Type: {2}<br>Key: <strong>{0}</strong>
+#register_otp_manual_message=Type: {2}<br>Key: {0}<br>Digits: {1}<br>Time Interval: {3}

--- a/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH_ja.properties
+++ b/openam-authentication/openam-auth-fr-oath/src/main/resources/amAuthAuthenticatorOATH_ja.properties
@@ -22,7 +22,7 @@
 # "Portions Copyrighted [year] [name of copyright owner]"
 #
 # Portions Copyrighted 2015 ForgeRock AS.
-# Portions Copyrighted 2019 Open Source Solution Technology Corporation
+# Portions Copyrighted 2019-2026 OSSTech Corporation
 #
 
 authentication=\u8a8d\u8a3c\u30e2\u30b8\u30e5\u30fc\u30eb
@@ -73,3 +73,7 @@ authFailed=\u8a8d\u8a3c\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002
 outOfSync=\u30c7\u30d0\u30a4\u30b9\u304c\u6700\u5927\u30af\u30ed\u30c3\u30af\u30c9\u30ea\u30d5\u30c8\u3092\u8d85\u3048\u307e\u3057\u305f\u3002\u304a\u4f7f\u3044\u306e\u30c7\u30d0\u30a4\u30b9\u3092\u518d\u767b\u9332\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 login_header=OATH Authenticator
 otpcodemiss=\u5165\u529b\u5024\u304c\u8aa4\u3063\u3066\u3044\u307e\u3059\u3002\u3042\u3068{0}\u56de\u9593\u9055\u3048\u308b\u3068\u6700\u521d\u304b\u3089\u3084\u308a\u76f4\u3057\u3068\u306a\u308a\u307e\u3059\u3002
+register_otp_algorithm_hotp=\u30ab\u30a6\u30f3\u30bf\u30fc\u30d9\u30fc\u30b9
+register_otp_algorithm_totp=\u6642\u9593\u30d9\u30fc\u30b9
+register_otp_manual_message=\u30bf\u30a4\u30d7: {2}<br>\u9375\u6587\u5b57\u5217: <strong>{0}</strong>
+#register_otp_manual_message=\u30bf\u30a4\u30d7: {2}<br>\u9375\u6587\u5b57\u5217: <strong>{0}</strong><br>\u6841\u6570: {1}<br>\u30a4\u30f3\u30bf\u30fc\u30d0\u30eb: {3}<br>

--- a/openam-server-only/src/main/webapp/config/auth/default/AuthenticatorOATH.xml
+++ b/openam-server-only/src/main/webapp/config/auth/default/AuthenticatorOATH.xml
@@ -14,7 +14,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS.
-  Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions copyright 2019-2026 OSSTech Corporation
  -->
 
 <!DOCTYPE ModuleProperties PUBLIC "=//iPlanet//Authentication Module Properties XML Interface 1.0 DTD//EN"
@@ -72,6 +72,9 @@
                 <OptionValue>
                     <Value>Login using verification code</Value>
                 </OptionValue>
+                <OptionValue>
+                    <Value>Unable to scan</Value>
+                </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
     </Callbacks>
@@ -101,6 +104,22 @@
                 </OptionValue>
                 <OptionValue>
                     <Value>Skip this step</Value>
+                </OptionValue>
+            </OptionValues>
+        </ConfirmationCallback>
+    </Callbacks>
+    <Callbacks length="3" order="8" timeout="120" header="Register your device with OpenAM">
+        <TextOutputCallback>
+            Open the application and enter the key.
+        </TextOutputCallback>
+        <TextOutputCallback>#REPLACE#</TextOutputCallback>
+        <ConfirmationCallback>
+            <OptionValues>
+                <OptionValue>
+                    <Value>Login using verification code</Value>
+                </OptionValue>
+                <OptionValue>
+                    <Value>Scan a barcode</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>

--- a/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
+++ b/openam-server-only/src/main/webapp/config/auth/default_ja/AuthenticatorOATH.xml
@@ -14,7 +14,7 @@
   information: "Portions copyright [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS.
-  Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions copyright 2019-2026 OSSTech Corporation
  -->
 
 <!DOCTYPE ModuleProperties PUBLIC "=//iPlanet//Authentication Module Properties XML Interface 1.0 DTD//EN"
@@ -72,6 +72,9 @@
                 <OptionValue>
                     <Value>次へ進む</Value>
                 </OptionValue>
+                <OptionValue>
+                    <Value>手動で入力(QRコードを読めない方はこちら)</Value>
+                </OptionValue>
             </OptionValues>
         </ConfirmationCallback>
     </Callbacks>
@@ -100,6 +103,22 @@
                 </OptionValue>
                 <OptionValue>
                     <Value>登録しないでログインする</Value>
+                </OptionValue>
+            </OptionValues>
+        </ConfirmationCallback>
+    </Callbacks>
+    <Callbacks length="3" order="8" timeout="120" header="手動でデバイスの登録">
+        <TextOutputCallback>
+             鍵文字列を登録してください。
+        </TextOutputCallback>
+        <TextOutputCallback>#REPLACE#</TextOutputCallback>
+        <ConfirmationCallback>
+            <OptionValues>
+                <OptionValue>
+                    <Value>次へ進む</Value>
+                </OptionValue>
+                <OptionValue>
+                    <Value>QRコードを表示する</Value>
                 </OptionValue>
             </OptionValues>
         </ConfirmationCallback>


### PR DESCRIPTION
## Solution

Add an `UNABLE TO SCAN` button to the device registration screen, allowing users to switch from the QR code to displaying the OTP type (Counter-based / Time-based) and the secret key string.

## Testing

* The device registration screen now allows switching from the QR code display to showing the OTP type and secret key string
* Devices can be registered using the secret key string