### PR TITLE
Issue #339 The common tasks screen is displayed in an unintended language

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/CommonTasksResource.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/CommonTasksResource.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2019 Open Source Solution Technology Corporation
+ * Portions copyright 2019-2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -39,10 +39,10 @@ import org.forgerock.json.resource.QueryRequest;
 import org.forgerock.json.resource.QueryResourceHandler;
 import org.forgerock.json.resource.QueryResponse;
 import org.forgerock.json.resource.ReadRequest;
-import org.forgerock.json.resource.Request;
 import org.forgerock.json.resource.ResourceException;
 import org.forgerock.json.resource.ResourceResponse;
 import org.forgerock.json.resource.UpdateRequest;
+import org.forgerock.openam.rest.resource.LocaleContext;
 import org.forgerock.util.promise.Promise;
 
 /**
@@ -134,7 +134,7 @@ class CommonTasksResource implements CollectionResourceProvider {
         if (!"true".equals(request.getQueryFilter().toString())) {
             return new NotSupportedException("Query not supported: " + request.getQueryFilter()).asPromise();
         }
-        JsonValue configuration = configurationManager.getCommonTasksConfiguration(getResourceBundle(request));
+        JsonValue configuration = configurationManager.getCommonTasksConfiguration(getResourceBundle(context));
         for (String key : configuration.keys()) {
             JsonValue resource = configuration.get(key);
             resource.add(ResourceResponse.FIELD_CONTENT_ID, key);
@@ -146,7 +146,7 @@ class CommonTasksResource implements CollectionResourceProvider {
     @Override
     public Promise<ResourceResponse, ResourceException> readInstance(Context context, String resourceId,
             ReadRequest request) {
-        JsonValue configuration = configurationManager.getCommonTasksConfiguration(getResourceBundle(request));
+        JsonValue configuration = configurationManager.getCommonTasksConfiguration(getResourceBundle(context));
         if (!configuration.isDefined(resourceId)) {
             return new BadRequestException("Invalid common task").asPromise();
         }
@@ -160,9 +160,8 @@ class CommonTasksResource implements CollectionResourceProvider {
         return new NotSupportedException().asPromise();
     }
 
-    private ResourceBundle getResourceBundle(Request request) {
-        return request.getPreferredLocales()
-                .getBundleInPreferredLocale(RESOURCE_BUNDLE_NAME, getClass().getClassLoader());
+    private ResourceBundle getResourceBundle(Context context) {
+        return ResourceBundle.getBundle(RESOURCE_BUNDLE_NAME, context.asContext(LocaleContext.class).getLocale());
     }
 
     private static final class CommonTasksConfigurationManager {

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRealmProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRealmProvider.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2019 Open Source Solution Technology Corporation
+ * Portions copyright 2019-2026 OSSTech Corporation
  */
 package org.forgerock.openam.core.rest.sms;
 
@@ -61,6 +61,7 @@ import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openam.core.CoreWrapper;
 import org.forgerock.openam.forgerockrest.utils.PrincipalRestUtils;
 import org.forgerock.openam.rest.RealmContext;
+import org.forgerock.openam.rest.resource.LocaleContext;
 import org.forgerock.openam.rest.RestConstants;
 import org.forgerock.openam.session.SessionCache;
 import org.forgerock.openam.utils.CollectionUtils;
@@ -77,6 +78,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -164,17 +166,16 @@ public class SmsRealmProvider implements RequestHandler {
                 return newResultPromise(newActionResponse(json(object(
                         field(PATH_ATTRIBUTE_NAME, "/"), field(ACTIVE_ATTRIBUTE_NAME, true)))));
             case RestConstants.SCHEMA:
-                return newResultPromise(newActionResponse(getSchema(request)));
+                return newResultPromise(newActionResponse(getSchema(context)));
             default:
             return new NotSupportedException("Action not supported: " + request.getAction()).asPromise();
         }
     }
 
-    private JsonValue getSchema(ActionRequest request) {
-        ResourceBundle consoleI18N = request.getPreferredLocales()
-                .getBundleInPreferredLocale("amConsole", getClass().getClassLoader());
-        ResourceBundle idRepoI18N = request.getPreferredLocales()
-                .getBundleInPreferredLocale("amIdRepoService", getClass().getClassLoader());
+    private JsonValue getSchema(Context context) {
+        Locale locale = context.asContext(LocaleContext.class).getLocale();
+        ResourceBundle consoleI18N = ResourceBundle.getBundle("amConsole", locale);
+        ResourceBundle idRepoI18N = ResourceBundle.getBundle("amIdRepoService", locale);
         return json(object(field("type", "object"), field("properties", object(
                 field(REALM_NAME_ATTRIBUTE_NAME, object(
                         field("type", "string"),

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsServerPropertiesResource.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsServerPropertiesResource.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Properties;
@@ -71,7 +73,6 @@ import org.apache.commons.io.IOUtils;
 import org.forgerock.http.routing.UriRouterContext;
 import org.forgerock.json.JsonPointer;
 import org.forgerock.json.JsonValue;
-import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.ActionResponse;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.InternalServerErrorException;
@@ -83,6 +84,7 @@ import org.forgerock.json.resource.annotations.Action;
 import org.forgerock.json.resource.annotations.Read;
 import org.forgerock.json.resource.annotations.RequestHandler;
 import org.forgerock.json.resource.annotations.Update;
+import org.forgerock.openam.rest.resource.LocaleContext;
 import org.forgerock.openam.rest.resource.SSOTokenContext;
 import org.forgerock.openam.utils.BundleUtils;
 import org.forgerock.openam.utils.CollectionUtils;
@@ -369,7 +371,7 @@ public class SmsServerPropertiesResource {
     }
 
     @Action
-    public Promise<ActionResponse, ResourceException> schema(ActionRequest request, Context serverContext) {
+    public Promise<ActionResponse, ResourceException> schema(Context serverContext) {
         Map<String, String> uriVariables = getUriTemplateVariables(serverContext);
 
         final String serverId = uriVariables.get("serverName");
@@ -399,8 +401,7 @@ public class SmsServerPropertiesResource {
         JsonValue schema;
         boolean isServerDefault = serverUrl.equalsIgnoreCase(SERVER_DEFAULT_NAME);
 
-        ResourceBundle titleBundle = request.getPreferredLocales()
-                .getBundleInPreferredLocale("amConsole", getClass().getClassLoader());
+        ResourceBundle titleBundle = ResourceBundle.getBundle("amConsole", getLocale(serverContext));
 
         if (ADVANCED_TAB_NAME.equals(tabName)) {
             schema = getAdvancedSchema(serverContext, serverUrl);
@@ -932,8 +933,7 @@ public class SmsServerPropertiesResource {
             logger.error("Invalid property", e);
         } catch (UnknownPropertyNameException e) {
             logger.warning("Unknown property found.", e);
-            ResourceBundle bundle = request.getPreferredLocales().getBundleInPreferredLocale("amConsole",
-                    getClass().getClassLoader());
+            ResourceBundle bundle = ResourceBundle.getBundle("amConsole", getLocale(serverContext));
             return new BadRequestException(
                     format(bundle.getString(UNKNOWN_PROPS), e.getMessage())).asPromise();
         }
@@ -1147,5 +1147,9 @@ public class SmsServerPropertiesResource {
         public boolean isPasswordField() {
             return isPasswordField;
         }
+    }
+
+    private Locale getLocale(Context context) {
+        return context.asContext(LocaleContext.class).getLocale();
     }
 }


### PR DESCRIPTION
## Analysis

See #339

## Solution

Modify to obtain the locale using `LocaleContext` as in other implementations.

## Testing

When passing `Accept-Language: en,ja;q=0.9`, the common tasks screen is displayed in English.