### PR TITLE
Issue #343 Devices are not displayed on the dashboard screen

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/DeviceManagementService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/DeviceManagementService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 /**
@@ -26,7 +27,7 @@ define([
 ], function ($, Configuration, Constants, AbstractDelegate, RealmHelper) {
     var obj = new AbstractDelegate(`${Constants.host}/${Constants.context}/json/`),
         getPath = function () {
-            return `__subrealm__/users/${Configuration.loggedUser.get("uid")}/devices/2fa/oath/`;
+            return `__subrealm__/users/${Configuration.loggedUser.get("username")}/devices/2fa/oath/`;
         };
 
     /**

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/FIDO2DeviceService.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/FIDO2DeviceService.jsm
@@ -11,7 +11,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2019 Open Source Solution Technology Corporation
+ * Copyright 2019-2026 OSSTech Corporation
  */
 
 import AbstractDelegate from "org/forgerock/commons/ui/common/main/AbstractDelegate";
@@ -21,7 +21,7 @@ import RealmHelper from "org/forgerock/openam/ui/common/util/RealmHelper";
 
 const delegate = new AbstractDelegate(`${Constants.host}/${Constants.context}/json/`);
 const getPath = function () {
-    return `__subrealm__/users/${Configuration.loggedUser.get("uid")}/devices/webauthn/`;
+    return `__subrealm__/users/${Configuration.loggedUser.get("username")}/devices/webauthn/`;
 };
 
 export function getAll () {

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/PushDeviceService.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/PushDeviceService.jsm
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 import AbstractDelegate from "org/forgerock/commons/ui/common/main/AbstractDelegate";
@@ -21,7 +22,7 @@ import RealmHelper from "org/forgerock/openam/ui/common/util/RealmHelper";
 
 const delegate = new AbstractDelegate(`${Constants.host}/${Constants.context}/json/`);
 const getPath = function () {
-    return `__subrealm__/users/${Configuration.loggedUser.get("uid")}/devices/push/`;
+    return `__subrealm__/users/${Configuration.loggedUser.get("username")}/devices/push/`;
 };
 
 export function getAll () {

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/TrustedDevicesService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/dashboard/services/TrustedDevicesService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 
@@ -28,7 +29,7 @@ define([
     obj.getTrustedDevices = function () {
         return obj.serviceCall({
             url: RealmHelper.decorateURIWithSubRealm(`__subrealm__/users/${
-                    Configuration.loggedUser.get("uid")
+                    Configuration.loggedUser.get("username")
                     }/devices/trusted/?_queryId=*`),
             headers: { "Cache-Control": "no-cache", "Accept-API-Version": "protocol=1.0,resource=1.0" }
         });
@@ -37,7 +38,7 @@ define([
     obj.deleteTrustedDevice = function (id) {
         return obj.serviceCall({
             url: RealmHelper.decorateURIWithSubRealm(`__subrealm__/users/${
-                Configuration.loggedUser.get("uid")
+                Configuration.loggedUser.get("username")
                 }/devices/trusted/${id}`),
             type: "DELETE",
             headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" }


### PR DESCRIPTION
## Solution

Use username instead of uid in the device retrieval endpoint path.

## Testing

* Devices can be displayed when the `LDAP Users Search Attribute` is changed
* Devices can be deleted when the `LDAP Users Search Attribute` is changed
