### PR TITLE
Issue #353 ClassCastException occurs when OpenAM is stopped

### DIFF
--- a/openam-authentication/openam-auth-windowsdesktopsso/src/main/java/com/sun/identity/authentication/modules/windowsdesktopsso/WindowsDesktopSSOConfig.java
+++ b/openam-authentication/openam-auth-windowsdesktopsso/src/main/java/com/sun/identity/authentication/modules/windowsdesktopsso/WindowsDesktopSSOConfig.java
@@ -24,6 +24,7 @@
  *
  * $Id: WindowsDesktopSSOConfig.java,v 1.3 2009/04/07 22:55:13 beomsuk Exp $
  *
+ * Portions Copyrighted 2026 OSSTech Corporation
  */
 
 
@@ -34,9 +35,12 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
 import com.iplanet.am.util.SystemProperties;
+import com.sun.identity.authentication.config.AMConfigurationEventListener;
 import com.sun.identity.shared.Constants;
 
-public class WindowsDesktopSSOConfig extends Configuration {
+public class WindowsDesktopSSOConfig extends Configuration
+    implements AMConfigurationEventListener {
+
     public static final String defaultAppName = 
         "com.sun.identity.authentication.windowsdesktopsso";
     private static final String kerberosModuleName = 
@@ -122,6 +126,13 @@ public class WindowsDesktopSSOConfig extends Configuration {
      */
     public void refresh() {
         config.refresh();
+    }
+
+    @Override
+    public void processListenerEvent(String name) {
+        if (config instanceof AMConfigurationEventListener) {
+            ((AMConfigurationEventListener)config).processListenerEvent(name);
+        }
     }
 }
 

--- a/openam-core/src/main/java/com/sun/identity/authentication/config/AMAuthLevelManager.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/config/AMAuthLevelManager.java
@@ -25,6 +25,7 @@
  * $Id: AMAuthLevelManager.java,v 1.3 2008/06/25 05:41:51 qcheng Exp $
  *
  * Portions Copyrighted 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 OSSTech Corporation
  */
 
 package com.sun.identity.authentication.config;
@@ -637,8 +638,10 @@ public class AMAuthLevelManager implements ServiceListener {
             if (debug.messageEnabled()) {
                 debug.message("processSMNotification, name=" + configName);
             }
-            ((AMConfiguration)Configuration.getConfiguration())
-                .processListenerEvent(configName);
+            Configuration config = Configuration.getConfiguration();
+            if (config instanceof AMConfigurationEventListener) {
+                ((AMConfigurationEventListener)config).processListenerEvent(configName);
+            }
         } 
 
         return needUpdate;

--- a/openam-core/src/main/java/com/sun/identity/authentication/config/AMConfiguration.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/config/AMConfiguration.java
@@ -25,6 +25,7 @@
  * $Id: AMConfiguration.java,v 1.9 2009/12/23 20:03:04 mrudul_uchil Exp $
  *
  * Portions Copyrighted 2015 ForgeRock AS.
+ * Portions Copyrighted 2026 OSSTech Corporation
  */
 
 package com.sun.identity.authentication.config;
@@ -58,7 +59,7 @@ import javax.security.auth.login.Configuration;
 /**
  * OpenAM JAAS Configuration implementation.
  */
-public class AMConfiguration extends Configuration {
+public class AMConfiguration extends Configuration implements AMConfigurationEventListener {
     
     /**
      * Holds all JAAS configuration, maps configuration name (String) to
@@ -685,6 +686,7 @@ public class AMConfiguration extends Configuration {
      *
      * @param name Configuration name.
      */
+    @Override
     public void processListenerEvent(String name) {
         synchronized (jaasConfig) {
             if (debug.messageEnabled()) {

--- a/openam-core/src/main/java/com/sun/identity/authentication/config/AMConfigurationEventListener.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/config/AMConfigurationEventListener.java
@@ -1,0 +1,29 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 OSSTech Corporation
+ */
+
+package com.sun.identity.authentication.config;
+
+public interface AMConfigurationEventListener {
+
+    /**
+     * Processes listener event, this method will remove configuration from
+     * the configuration cache, also remove the listener from the listened
+     * object, such as <code>AMUser</code>, <code>AMRole</code>, or SM Service.
+     *
+     * @param name Configuration name.
+     */
+    public void processListenerEvent(String name);
+}


### PR DESCRIPTION
## Analysis

See #353

## Solution

Migrate `AMConfiguration.processListenerEvent()` to a new interface and implement it in `WindowsDesktopSSOConfig`.

## Testing

* `ClassCastException` does not occur when stopping OpenAM
* `ClassCastException` does not occur even if the configuration is changed after Desktop SSO authentication has been performed
