### PR TITLE
Issue #355 The response from the REST API includes details of JSON parse errors

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/http/AuthenticationServiceV1.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/http/AuthenticationServiceV1.java
@@ -12,12 +12,14 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.authn.http;
 
 import static org.forgerock.json.JsonValue.*;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.iplanet.sso.SSOException;
 import com.iplanet.sso.SSOTokenManager;
 import com.sun.identity.authentication.client.AuthClientUtils;
@@ -74,6 +76,9 @@ public class AuthenticationServiceV1 {
     private static final String CONTENT_TYPE_HEADER_NAME = "Content-Type";
     private static final String REALM = "realm";
     private static final String JSONCONTENT = "jsonContent";
+
+    protected static final String ERRMSG_INVALID_JSON =
+            "The request could not be processed because the provided content is not valid JSON";
 
     private final RestAuthenticationHandler restAuthenticationHandler;
 
@@ -324,6 +329,8 @@ public class AuthenticationServiceV1 {
             }
             rep.put("errorMessage", getLocalizedMessage(request, exception));
 
+        } else if (exception instanceof JsonParseException) {
+            rep.put("errorMessage", ERRMSG_INVALID_JSON);
         } else if (exception == null) {
             rep.put("errorMessage", status.getReasonPhrase());
         } else {

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/http/AuthenticationServiceV2.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/http/AuthenticationServiceV2.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.authn.http;
@@ -30,6 +31,8 @@ import org.forgerock.openam.core.rest.authn.RestAuthenticationHandler;
 import org.forgerock.openam.core.rest.authn.exceptions.RestAuthException;
 import org.forgerock.openam.core.rest.authn.exceptions.RestAuthResponseException;
 import org.forgerock.util.Reject;
+
+import com.fasterxml.jackson.core.JsonParseException;
 
 /**
  *
@@ -68,6 +71,9 @@ public class AuthenticationServiceV2 extends AuthenticationServiceV1 {
 
             return createExceptionResponse(response, cause);
 
+        } else if (exception instanceof JsonParseException) {
+            return createExceptionResponse(response,
+                    ResourceException.getException(status.getCode(), ERRMSG_INVALID_JSON, exception));
         } else if (exception == null) {
             return createExceptionResponse(response, ResourceException.getException(status.getCode()));
 


### PR DESCRIPTION
## Solution

Do not include details of JSON parse errors in the REST API response.

## Testing

The REST API response of OpenAM does not include details of JSON parse errors.