### PR TITLE
Issue #362 Cannot operate Sub-Sub Configuration with the REST API of Global Service

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,8 +106,8 @@ public abstract class SmsResourceProvider {
     protected final SmsJsonConverter converter;
     protected final Debug debug;
     protected final ServiceSchema schema;
-    private final AMResourceBundleCache resourceBundleCache;
-    private final Locale defaultLocale;
+    protected final AMResourceBundleCache resourceBundleCache;
+    protected final Locale defaultLocale;
 
     SmsResourceProvider(ServiceSchema schema, SchemaType type, List<ServiceSchema> subSchemaPath, String uriPath,
             boolean serviceHasInstanceName, SmsJsonConverter converter, Debug debug,
@@ -160,7 +161,7 @@ public abstract class SmsResourceProvider {
     protected ServiceConfig parentSubConfigFor(Context context, ServiceConfigManager scm)
             throws SMSException, SSOException, NotFoundException {
 
-        Map<String, String> uriTemplateVariables = context.asContext(UriRouterContext.class).getUriTemplateVariables();
+        Map<String, String> uriTemplateVariables = getUriTemplateVariables(context);
 
         ServiceConfig config;
         if (type == SchemaType.GLOBAL) {
@@ -194,6 +195,16 @@ public abstract class SmsResourceProvider {
             }
         }
         return config;
+    }
+
+    static Map<String, String> getUriTemplateVariables(Context context) {
+        Map<String, String> uriTemplateVariables = new HashMap<>();
+        Context c = context;
+        while (c.containsContext(UriRouterContext.class)) {
+            uriTemplateVariables.putAll(c.asContext(UriRouterContext.class).getUriTemplateVariables());
+            c = c.getParent();
+        }
+        return uriTemplateVariables;
     }
 
     /**

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsResourceProviderTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsResourceProviderTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyrighted 2019 Open Source Solution Technology Corporation.
+ * Portions copyright 2019-2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -31,6 +31,7 @@ import org.forgerock.json.test.assertj.AssertJJsonValueAssert;
 import org.forgerock.openam.rest.RealmContext;
 import org.forgerock.openam.rest.resource.LocaleContext;
 import org.forgerock.services.context.Context;
+import org.forgerock.services.context.RootContext;
 import org.forgerock.util.test.assertj.Conditions;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -94,6 +95,7 @@ public class SmsResourceProviderTest {
         when(localeContext.getLocale()).thenReturn(local);
         when(mockContext.asContext(LocaleContext.class)).thenReturn(localeContext);
 
+        when(mockContext.getParent()).thenReturn(new RootContext());
         when(mockContext.containsContext(RealmContext.class)).thenReturn(true);
         when(mockContext.asContext(RealmContext.class)).thenReturn(mockRealmContext);
         when(mockRealmContext.getResolvedRealm()).thenReturn(RESOLVED_REALM);
@@ -154,6 +156,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         Assertions.assertThat(rp.parentSubConfigFor(mockContext, mockServiceConfigManager)).isEqualTo(mockServiceConfig);
@@ -168,6 +171,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(false);
 
         rp.parentSubConfigFor(mockContext, mockServiceConfigManager);
@@ -187,6 +191,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn("resourceName");
@@ -211,6 +216,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn("resourceName");
@@ -234,6 +240,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn(SmsRequestHandler.USE_PARENT_PATH);
@@ -260,6 +267,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/uri", "", Collections.<String, String>emptyMap());
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn(SmsRequestHandler.USE_PARENT_PATH);
@@ -288,6 +296,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/{placeholder}", "", uriTemplaceVariables);
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn("placeholder");
@@ -315,6 +324,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/{placeholder}", "", uriTemplaceVariables);
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn("placeholder");
@@ -342,6 +352,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/{placeholder}", "", uriTemplaceVariables);
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn(SmsRequestHandler.USE_PARENT_PATH);
@@ -371,6 +382,7 @@ public class SmsResourceProviderTest {
         UriRouterContext urc = new UriRouterContext(mockContext, "/{placeholder}", "", uriTemplaceVariables);
 
         when(mockContext.asContext(UriRouterContext.class)).thenReturn(urc);
+        when(mockContext.containsContext(UriRouterContext.class)).thenReturn(true);
         when(mockServiceConfig.exists()).thenReturn(true);
 
         when(branch.getResourceName()).thenReturn(SmsRequestHandler.USE_PARENT_PATH);


### PR DESCRIPTION
## Solution

Fix the issue where Sub-Sub Configuration could not be operated, referring to c355798c7210aa61c06912969177a0768d5ac760 and 784a2542838674239e94a1239e9a959521429c05.

## Testing

The following APIs work fine.

* POST /json/global-config/services/scripting/contexts/AUTHENTICATION_SERVER_SIDE?_action=nextdescendents
* POST /json/global-config/services/scripting/contexts/AUTHENTICATION_SERVER_SIDE?_action=getCreatableTypes
* GET /json/global-config/services/scripting/contexts/AUTHENTICATION_SERVER_SIDE/engineConfiguration
* PUT /json/global-config/services/scripting/contexts/AUTHENTICATION_SERVER_SIDE/engineConfiguration
