### PR TITLE
Issue #383 When the agent group to which an agent belongs is deleted, some inheritance settings are lost

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/common/configuration/AgentConfiguration.java
+++ b/openam-core/src/main/java/com/sun/identity/common/configuration/AgentConfiguration.java
@@ -1700,7 +1700,7 @@ public class AgentConfiguration {
         }
         for (Iterator i = attrValues.entrySet().iterator(); i.hasNext(); ) {
             Map.Entry entry = (Map.Entry)i.next();
-            String correctedKey = (String)mapCase.get(entry.getKey());
+            String correctedKey = (String)mapCase.get(((String)entry.getKey()).toLowerCase());
             if (correctedKey != null) { // can be null like "agenttype"
                 results.put(correctedKey, entry.getValue());
             }


### PR DESCRIPTION
## Solution

Fix the method for obtaining the correct attribute name.

## Testing

Perform the reproduction steps described in the issue, then agent's `Status` is not lost.