### PR TITLE
Issue #385 The response of adaptive risk authentication is not divided into sections

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
@@ -666,7 +666,10 @@ public class SmsJsonConverter {
 
     protected Map<String, String> getAttributeNameToSection() {
         Map<String, String> result = new LinkedHashMap();
-        String serviceSectionFilename = schema.getName() != null ? schema.getName() : schema.getServiceName();
+        String serviceSectionFilename = schema.getName();
+        if (serviceSectionFilename == null || serviceSectionFilename.equals("serverconfig")) {
+            serviceSectionFilename = schema.getServiceName();
+        }
         serviceSectionFilename = serviceSectionFilename + ".section.properties";
 
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream(serviceSectionFilename);

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authentication/modules/EditModuleView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authentication/modules/EditModuleView.js
@@ -73,7 +73,8 @@ define([
             .update(this.data.realmPath, this.data.name, this.data.type, this.data.form.data())
             .then((data) => {
                 // Update the form data for re-render the tab
-                _.extend(self.data.form.values, data);
+                _.extend(self.data.form.values, self.data.form.data());
+                _.extend(self.data.values, data);
                 EventManager.sendEvent(Constants.EVENT_DISPLAY_MESSAGE_REQUEST, "changesSaved");
             }, (response) => {
                 Messages.addMessage({
@@ -90,7 +91,7 @@ define([
                 schema = this.data.schema.properties[id],
                 element = this.$el.find("#tabpanel").empty().get(0);
 
-            this.data.form = new Form(element, schema, this.data.values);
+            this.data.form = new Form(element, schema, this.data.values[id]);
             this.$el.find("[data-header]").parent().hide();
         }
     });


### PR DESCRIPTION
## Solution

Change the instance response of the authentication module to be divided into sections.

## Testing

* The response from the adaptive risk authentication instance is divided into sections
* The configuration is displayed correctly in the admin console