### PR TITLE
Issue #391 Restrict attributes that general users can modify

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/IdentityResourceV1.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/IdentityResourceV1.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 package org.forgerock.openam.core.rest;
 
@@ -111,6 +112,9 @@ import com.sun.identity.sm.SMSException;
 import com.sun.identity.sm.ServiceConfig;
 import com.sun.identity.sm.ServiceConfigManager;
 import com.sun.identity.sm.ServiceNotFoundException;
+
+import jp.co.osstech.openam.services.security.RestSecurityConfig;
+import jp.co.osstech.openam.services.security.RestSecurityConfig.RestSecurityConfigBuilder;
 
 /**
  * A simple {@code Map} based collection resource provider.
@@ -1373,6 +1377,17 @@ public final class IdentityResourceV1 implements CollectionResourceProvider {
                 throw new BadRequestException("id in path does not match id in request body");
             }
             newDtls.setName(resourceId);
+
+            RestSecurityConfig restSecurityConfig = configHandler.getConfig(realm, RestSecurityConfigBuilder.class);
+            Set<String> selfWriteUserAttributes = restSecurityConfig.getSelfWriteUserAttributes();
+            if (!selfWriteUserAttributes.isEmpty() && !isAdmin(context)) {
+                for (String key : jsonValue.keys()) {
+                    if (!USER_PASSWORD.equalsIgnoreCase(key)
+                            && !selfWriteUserAttributes.contains(key)) {
+                        throw new BadRequestException("Unmodifiable attribute is specified for update");
+                    }
+                }
+            }
 
             // update resource with new details
             identityServices.update(newDtls, admin);

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/IdentityResourceV2.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/IdentityResourceV2.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest;
@@ -74,6 +75,10 @@ import com.sun.identity.sm.ServiceConfig;
 import com.sun.identity.sm.ServiceConfigManager;
 import com.sun.identity.sm.ServiceListener;
 import com.sun.identity.sm.ServiceNotFoundException;
+
+import jp.co.osstech.openam.services.security.RestSecurityConfig;
+import jp.co.osstech.openam.services.security.RestSecurityConfig.RestSecurityConfigBuilder;
+
 import org.apache.commons.lang.RandomStringUtils;
 import org.forgerock.guice.core.InjectorHolder;
 import org.forgerock.openam.sm.config.ConsoleConfigHandler;
@@ -1277,6 +1282,17 @@ public final class IdentityResourceV2 implements CollectionResourceProvider, Ser
                 throw new BadRequestException("id in path does not match id in request body");
             }
             newDtls.setName(resourceId);
+
+            RestSecurityConfig restSecurityConfig = configHandler.getConfig(realm, RestSecurityConfigBuilder.class);
+            Set<String> selfWriteUserAttributes = restSecurityConfig.getSelfWriteUserAttributes();
+            if (!selfWriteUserAttributes.isEmpty() && !isAdmin(context)) {
+                for (String key : jVal.keys()) {
+                    if (!USER_PASSWORD.equalsIgnoreCase(key)
+                            && !selfWriteUserAttributes.contains(key)) {
+                        throw new BadRequestException("Unmodifiable attribute is specified for update");
+                    }
+                }
+            }
 
             UserAttributeInfo userAttributeInfo = configHandler.getConfig(realm, UserAttributeInfoBuilder.class);
 

--- a/openam-core/src/main/java/org/forgerock/openam/sm/config/ConsoleConfigHandlerImpl.java
+++ b/openam-core/src/main/java/org/forgerock/openam/sm/config/ConsoleConfigHandlerImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 package org.forgerock.openam.sm.config;
 
@@ -209,14 +210,17 @@ public final class ConsoleConfigHandlerImpl implements ConsoleConfigHandler {
     }
 
     private void notifyListeners(String source, String orgName) {
-        List<ConsoleConfigListener> listeners = sourceListeners.get(source);
 
+        String realm = dnUtils.orgNameToRealmName(orgName);
+
+        if (registeredSources.contains(source)) {
+            attributeCache.remove(CacheKey.newInstance(source, realm));
+        }
+
+        List<ConsoleConfigListener> listeners = sourceListeners.get(source);
         if (isEmpty(listeners)) {
             return;
         }
-
-        String realm = dnUtils.orgNameToRealmName(orgName);
-        attributeCache.remove(CacheKey.newInstance(source, realm));
 
         for (ConsoleConfigListener listener : listeners) {
             try {

--- a/openam-rest/src/main/java/jp/co/osstech/openam/services/security/RestSecurityConfig.java
+++ b/openam-rest/src/main/java/jp/co/osstech/openam/services/security/RestSecurityConfig.java
@@ -1,0 +1,65 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 OSSTech Corporation
+ */
+package jp.co.osstech.openam.services.security;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.sun.identity.common.CaseInsensitiveHashSet;
+import org.forgerock.openam.sm.config.ConfigAttribute;
+import org.forgerock.openam.sm.config.ConfigSource;
+import org.forgerock.openam.sm.config.ConsoleConfigBuilder;
+
+/**
+ * REST security configuration.
+ */
+public final class RestSecurityConfig {
+
+    private final Set<String> selfWriteUserAttributes;
+
+    public RestSecurityConfig(RestSecurityConfigBuilder builder) {
+        selfWriteUserAttributes = builder.selfWriteUserAttributes;
+    }
+
+    /**
+     * Gets the set of user attributes that users can write to themselves.
+     *
+     * @return self-writeable user attributes
+     */
+    public Set<String> getSelfWriteUserAttributes() {
+        return selfWriteUserAttributes;
+    }
+
+    @ConfigSource("RestSecurity")
+    public static final class RestSecurityConfigBuilder implements ConsoleConfigBuilder<RestSecurityConfig> {
+
+        private final Set<String> selfWriteUserAttributes;
+
+        public RestSecurityConfigBuilder() {
+            selfWriteUserAttributes = new CaseInsensitiveHashSet<>();
+        }
+
+        @ConfigAttribute(value = "selfWriteUserAttributes", required = false)
+        public void setSelfWriteUserAttributes(Set<String> selfWriteUserAttributes) {
+            this.selfWriteUserAttributes.addAll(selfWriteUserAttributes);
+        }
+
+        @Override
+        public RestSecurityConfig build(Map<String, Set<String>> attributes) {
+            return new RestSecurityConfig(this);
+        }
+    }
+}

--- a/openam-rest/src/main/resources/RestSecurity.properties
+++ b/openam-rest/src/main/resources/RestSecurity.properties
@@ -21,6 +21,7 @@
 # your own identifying information:
 # "Portions copyright [year] [name of copyright owner]"
 #
+# Portions copyright 2026 OSSTech Corporation
 
 forgerock-restSecurity-service-description=Legacy User Self Service
 a100=Legacy Self-Service REST Endpoint
@@ -35,3 +36,4 @@ a107a=User is sent to a 'successful registration' page, without being logged in.
 a107b=User is sent to the login page, to authenticate.
 a107c=User is automatically logged in and sent to the appropriate page within the system.
 a108=Protected User Attributes
+a109=Self Writable User Attributes

--- a/openam-rest/src/main/resources/RestSecurity.xml
+++ b/openam-rest/src/main/resources/RestSecurity.xml
@@ -24,6 +24,8 @@
    with the fields enclosed by brackets [] replaced by
    your own identifying information:
    "Portions copyright [year] [name of copyright owner]"
+
+   Portions copyright 2026 OSSTech Corporation
 -->
 
 <ServicesConfiguration>
@@ -145,6 +147,19 @@
                                  i18nKey="a108"
                                  order="900">
                 </AttributeSchema> 
+                <AttributeSchema name="selfWriteUserAttributes"
+                                 type="list"
+                                 syntax="string"
+                                 resourceName="selfWriteUserAttributes"
+                                 i18nKey="a109"
+                                 order="2100">
+                    <DefaultValues>
+                        <Value>givenName</Value>
+                        <Value>sn</Value>
+                        <Value>mail</Value>
+                        <Value>telephoneNumber</Value>
+                    </DefaultValues>
+                </AttributeSchema>
             </Organization>
         </Schema>
     </Service>

--- a/openam-rest/src/main/resources/RestSecurity_ja.properties
+++ b/openam-rest/src/main/resources/RestSecurity_ja.properties
@@ -23,7 +23,7 @@
 #
 
 # Portions Copyrighted 2014 ForgeRock AS
-# Portions Copyrighted 2014 Open Source Solution Technology Corporation
+# Portions Copyrighted 2014-2026 OSSTech Corporation
 # Portions Copyrighted 2014 Nomura Research Institute, Ltd
 
 forgerock-restSecurity-service-description=REST \u30bb\u30ad\u30e5\u30ea\u30c6\u30a3
@@ -33,3 +33,4 @@ a103=\u81ea\u5df1\u767b\u9332\u78ba\u8a8d\u30e1\u30fc\u30eb\u306e URL
 a104=\u30d1\u30b9\u30ef\u30fc\u30c9\u3092\u5fd8\u308c\u305f\u30e6\u30fc\u30b6\u30fc\u306e\u305f\u3081\u306e\u30ea\u30bb\u30c3\u30c8
 a105=\u30d1\u30b9\u30ef\u30fc\u30c9\u30ea\u30bb\u30c3\u30c8\u30c8\u30fc\u30af\u30f3\u306e\u6709\u52b9\u671f\u9593 (\u79d2)
 a106=\u30d1\u30b9\u30ef\u30fc\u30c9\u30ea\u30bb\u30c3\u30c8\u78ba\u8a8d\u96fb\u5b50\u30e1\u30fc\u30eb URL
+a109=\u81ea\u8eab\u3067\u66f8\u304d\u63db\u3048\u53ef\u80fd\u306a\u30e6\u30fc\u30b6\u30fc\u5c5e\u6027

--- a/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
+++ b/openam-server-only/src/main/webapp/WEB-INF/template/sms/serverupgrade.properties
@@ -41,5 +41,6 @@ upgrade.helper=iPlanetAMLoggingService=org.forgerock.openam.upgrade.helpers.Logg
   iPlanetAMAuthOpenIdConnectService=org.forgerock.openam.upgrade.helpers.OpenIdConnectAuthModuleServiceHelper,\
   sunFAMFederationCommon=jp.co.osstech.openam.upgrade.helpers.FederationCommonUpgradeHelper,\
   RestSecurityTokenService=jp.co.osstech.openam.upgrade.helpers.RestSTSUpgradeHelper,\
-  SoapSecurityTokenService=jp.co.osstech.openam.upgrade.helpers.SoapSTSUpgradeHelper
+  SoapSecurityTokenService=jp.co.osstech.openam.upgrade.helpers.SoapSTSUpgradeHelper,\
+  RestSecurity=jp.co.osstech.openam.upgrade.helpers.RestSecurityUpgradeHelper
 services.to.delete=iPlanetAMAuthSafeWordService,iPlanetAMAuthUnixService,sunFAMLibertyInteractionService,sunFAMLibertySecurityService,sunAMAuthWSSAuthModuleService,sunFAMSTSService,iPlanetAMAuthDevicePrintModuleService

--- a/openam-ui/openam-ui-ria/src/main/js/jp/co/osstech/openam/ui/user/profile/AMUserProfileKBAView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/jp/co/osstech/openam/ui/user/profile/AMUserProfileKBAView.js
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 OSSTech Corporation
+ */
+
+define([
+    "jquery",
+    "lodash",
+    "org/forgerock/commons/ui/user/profile/UserProfileKBAView",
+    "jp/co/osstech/openam/ui/user/profile/AMUserProfileView"
+], function ($, _,
+    UserProfileKBAView,
+    AMUserProfileView) {
+
+    var AMUserProfileKBAView = Object.create(UserProfileKBAView);
+
+    AMUserProfileKBAView.validationSuccessful =
+        function (event) {
+            if (!event || !event.target) {
+                return $.Deferred().reject();
+            }
+            const target = $(event.target);
+            const form = target.closest("form");
+            if (form.attr("id") === "KBA") {
+                UserProfileKBAView.validationSuccessful.call(this, event);
+            } else {
+                AMUserProfileView.validationSuccessful.call(this, event);
+            }
+        };
+
+    return AMUserProfileKBAView;
+});
+

--- a/openam-ui/openam-ui-ria/src/main/js/jp/co/osstech/openam/ui/user/profile/AMUserProfileView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/jp/co/osstech/openam/ui/user/profile/AMUserProfileView.js
@@ -1,0 +1,73 @@
+/**
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 OSSTech Corporation
+ */
+
+define([
+    "jquery",
+    "underscore",
+    "org/forgerock/commons/ui/common/main/Configuration",
+    "org/forgerock/commons/ui/common/main/ValidatorsManager",
+    "org/forgerock/commons/ui/common/util/ModuleLoader",
+    "org/forgerock/commons/ui/user/profile/UserProfileView"
+], function ($, _,
+    Configuration,
+    ValidatorsManager,
+    ModuleLoader,
+    UserProfileView) {
+
+    var AMUserProfileView = Object.create(UserProfileView);
+
+    AMUserProfileView.validationSuccessful =
+        function (event) {
+            if (!event || !event.target) {
+                return $.Deferred().reject();
+            }
+            ModuleLoader.load("bootstrap")
+            .then(function () {
+                return $(event.target);
+            })
+            .then(
+                _.bind(function (input) {
+                    if (input.data()["bs.popover"]) {
+                        input.popover("destroy");
+                    }
+                    input.parents(".form-group").removeClass("has-feedback has-error");
+
+                    const form = input.closest("form");
+                    if (form.attr("id") === "password") {
+                        $(form).find("input[type='submit']").prop("disabled", !ValidatorsManager.formValidated(form));
+                    } else {
+                        const formData = _.mapValues(this.getFormContent(form[0]),
+                            function (val) {
+                                return typeof val === "string" ? val.trim() : val;
+                            });
+                        const currentData =
+                            _(Configuration.loggedUser.toJSON())
+                                .chain()
+                                .pick(["username", "givenName", "sn", "mail", "telephoneNumber"])
+                                .defaults({ "givenName" : "", "sn" : "", "mail" : "", "telephoneNumber" : "" })
+                                .value();
+                        if (!_.isEqual(formData, currentData) && ValidatorsManager.formValidated(form)) {
+                            $(form).find("input[type='submit']").prop("disabled", false);
+                        } else {
+                            $(form).find("input[type='submit']").prop("disabled", true);
+                        }
+                    }
+                }, this)
+            );
+        };
+
+    return AMUserProfileView;
+});

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/services/SiteConfigurationService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/services/SiteConfigurationService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 define([
@@ -29,8 +30,8 @@ define([
         setRequireMapConfig = function (serverInfo) {
             require.config({ "map": { "*": {
                 "UserProfileView" : (serverInfo.kbaEnabled === "true"
-                    ? "org/forgerock/commons/ui/user/profile/UserProfileKBAView"
-                    : "org/forgerock/commons/ui/user/profile/UserProfileView")
+                    ? "jp/co/osstech/openam/ui/user/profile/AMUserProfileKBAView"
+                    : "jp/co/osstech/openam/ui/user/profile/AMUserProfileView")
             } } });
 
             return serverInfo;

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/UserModel.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/UserModel.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 define([
@@ -54,6 +55,18 @@ define([
                     };
 
                 if (method === "update" || method === "patch") {
+                    const updateData = {};
+                    _.forIn(this.changed,
+                        _.bind(
+                            function (val, key) {
+                                if ((val === "") && !(this._previousAttributes[key])) {
+                                    return;
+                                }
+                                if (this._previousAttributes[key] !== val) {
+                                    updateData[key] = val;
+                                }
+                            }, this));
+
                     if (_.has(this.changed, "password")) {
                         // password changes have to occur via a special rest call
                         return ServiceInvoker.restCall({
@@ -78,7 +91,7 @@ define([
                             {
                                 type: "PUT",
                                 data: JSON.stringify(
-                                    _.chain(this.toJSON())
+                                    _.chain(updateData)
                                         .pick(["givenName", "sn", "mail", "postalAddress", "telephoneNumber"])
                                         .mapValues(function (val) {
                                             return typeof val === "string" ? val.trim() : val;

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/KBADelegate.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/KBADelegate.js
@@ -12,18 +12,43 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 define([
+    "lodash",
+    "org/forgerock/commons/ui/common/main/Configuration",
     "org/forgerock/commons/ui/common/util/Constants",
     "org/forgerock/commons/ui/user/delegates/KBADelegate",
     "org/forgerock/openam/ui/common/util/RealmHelper"
-], function (Constants, KBADelegate, RealmHelper) {
+], function (_, Configuration, Constants, KBADelegate, RealmHelper) {
 
     KBADelegate.serviceUrl = RealmHelper.decorateURIWithSubRealm(`/${Constants.context}/json/__subrealm__/${
             Constants.SELF_SERVICE_CONTEXT
         }`);
     KBADelegate.baseEntity = RealmHelper.decorateURIWithSubRealm(`json/__subrealm__/${Constants.SELF_SERVICE_CONTEXT}`);
+
+    KBADelegate.saveInfo = function (user) {
+        return this.serviceCall({
+            "type": "PATCH",
+            "url": "user/" + Configuration.loggedUser.id,
+            "data": JSON.stringify(
+                _(user)
+                 .map(function (value, key) {
+                     return {
+                         "operation": "replace",
+                         "field": "/" + key,
+                         // replace the whole value, rather than just the parts that have changed,
+                         // since there is no consistent way to target items in a set across the stack
+                         "value": value
+                     };
+                 })
+            )
+        }).then(function (updatedUser) {
+            updatedUser.roles = Configuration.loggedUser.get("roles");
+            Configuration.loggedUser.set(Configuration.loggedUser.parse(updatedUser));
+        });
+    };
 
     return KBADelegate;
 });

--- a/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/helpers/RestSecurityUpgradeHelper.java
+++ b/openam-upgrade/src/main/java/jp/co/osstech/openam/upgrade/helpers/RestSecurityUpgradeHelper.java
@@ -1,0 +1,47 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 OSSTech Corporation
+ */
+package jp.co.osstech.openam.upgrade.helpers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.forgerock.openam.upgrade.UpgradeException;
+
+import com.sun.identity.sm.AbstractUpgradeHelper;
+import com.sun.identity.sm.AttributeSchemaImpl;
+
+/**
+ * This upgrade helper is used to handle Rest Security schema.
+ */
+public class RestSecurityUpgradeHelper extends AbstractUpgradeHelper {
+
+    private static final String SELF_WRITEABLE_ATTRIBUTES = "selfWriteUserAttributes";
+
+    @Override
+    public AttributeSchemaImpl addNewAttribute(Set<AttributeSchemaImpl> existingAttrs, AttributeSchemaImpl newAttr)
+            throws UpgradeException {
+        if (SELF_WRITEABLE_ATTRIBUTES.equals(newAttr.getName())) {
+            updateDefaultValues(newAttr, new HashSet<String>());
+        }
+        return super.addNewAttribute(existingAttrs, newAttr);
+    }
+
+    @Override
+    public AttributeSchemaImpl upgradeAttribute(AttributeSchemaImpl oldAttr, AttributeSchemaImpl newAttr)
+            throws UpgradeException {
+        return newAttr;
+    }
+}


### PR DESCRIPTION
## Solution

* Add `Self Writable User Attributes` setting to `RestSecurity`
* If attributes not included in the above setting are specified in the user REST API (`/json/users`) update process, an error will be returned

## Testing

* User REST API
    * Update succeeds when writable attributes are specified
    * Error occurs when non-writable attributes are specified
* User Profile Screen
    * Update succeeds when writable attributes are specified
    * Error occurs when non-writable attributes are specified
    * Password can be changed
    * Secret questions can be changed