### PR TITLE
Issue #395 Internal Server Error is returned by the global user self-service REST API

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsGlobalSingletonProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsGlobalSingletonProvider.java
@@ -104,7 +104,7 @@ public class SmsGlobalSingletonProvider extends SmsSingletonProvider {
     @Override
     protected void addOrganisationAttributes(String realm, ServiceConfig config, JsonValue result) {
         if (organizationSchema != null) {
-            result.add("defaults", organizationConverter.toJson(organizationSchema.getAttributeDefaults(), true)
+            result.add("defaults", organizationConverter.toJson(organizationSchema.getAttributeDefaults(), false)
                     .getObject());
         }
     }


### PR DESCRIPTION
## Solution

As with `SmsResourceProvider`, `SmsGlobalSingletonProvider.addOrganisationAttributes()` does not perform attribute validation.

## Testing

The global user self-service REST API works correctly even after changing the keystore file.