### PR TITLE
Issue #397 There is no debug output when Responder status is received from SAML IdP

### DIFF
--- a/openam-server-only/src/main/webapp/saml2/jsp/spAssertionConsumer.jsp
+++ b/openam-server-only/src/main/webapp/saml2/jsp/spAssertionConsumer.jsp
@@ -25,6 +25,7 @@
    $Id: spAssertionConsumer.jsp,v 1.17 2010/01/23 00:07:06 exu Exp $
 
    Portions Copyrighted 2012-2016 ForgeRock AS.
+   Portions Copyrighted 2026 OSSTech Corporation
 --%>
 
 <%@page
@@ -241,20 +242,18 @@ java.io.PrintWriter
             data[2] = saml2Resp.toXMLString(true, true);
         }
         LogUtil.error(Level.INFO, LogUtil.SP_SSO_FAILED, data, null);
-        if (se instanceof InvalidStatusCodeSaml2Exception) {
-            if (isProxyOn) {
-                SAML2Utils.debug.error("spAssertionConsumer.jsp: Non-Success status code in response");
-                String firstlevelStatusCodeValue = ((InvalidStatusCodeSaml2Exception) se).getFirstlevelStatuscode();
-                String secondlevelStatusCodeValue = ((InvalidStatusCodeSaml2Exception) se).getSecondlevelStatuscode();
-                try {
-                    IDPProxyUtil.sendResponseWithStatus(request, response, new PrintWriter(out, true),
-                            requestID, metaAlias, hostEntityId, realm, firstlevelStatusCodeValue,
-                            secondlevelStatusCodeValue);
-                } catch (SAML2Exception samle) {
-                    SAML2Utils.debug.error("Failed to send response with status ", samle);
-                }
-                return;
+        if (se instanceof InvalidStatusCodeSaml2Exception && isProxyOn) {
+            SAML2Utils.debug.error("spAssertionConsumer.jsp: Non-Success status code in response");
+            String firstlevelStatusCodeValue = ((InvalidStatusCodeSaml2Exception) se).getFirstlevelStatuscode();
+            String secondlevelStatusCodeValue = ((InvalidStatusCodeSaml2Exception) se).getSecondlevelStatuscode();
+            try {
+                IDPProxyUtil.sendResponseWithStatus(request, response, new PrintWriter(out, true),
+                        requestID, metaAlias, hostEntityId, realm, firstlevelStatusCodeValue,
+                        secondlevelStatusCodeValue);
+            } catch (SAML2Exception samle) {
+                SAML2Utils.debug.error("Failed to send response with status ", samle);
             }
+            return;
         } else {
             SAML2Utils.debug.error("spAssertionConsumer.jsp: SSO failed.", se);
             if (se.isRedirectionDone()) {


### PR DESCRIPTION
## Solution

Fix the exception handling in `spAssertionConsumer.jsp`.

## Testing

When `Responder` status is received from the SAML IdP, there is debug output.