### PR TITLE
Issue #411 POST_PROCESS_LOGIN_SUCCESS_URL is not effective when the goto parameter is present

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/core/CompletedLoginProcess.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/core/CompletedLoginProcess.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 package org.forgerock.openam.core.rest.authn.core;
@@ -22,6 +23,8 @@ import com.sun.identity.authentication.spi.AuthLoginException;
 import com.sun.identity.authentication.spi.PagePropertiesCallback;
 import com.sun.identity.authentication.util.ISAuthConstants;
 import org.forgerock.openam.core.rest.authn.core.wrappers.CoreServicesWrapper;
+import org.forgerock.openam.security.whitelist.ValidGotoUrlExtractor;
+import org.forgerock.openam.shared.security.whitelist.RedirectUrlValidator;
 
 import javax.security.auth.callback.Callback;
 
@@ -108,8 +111,12 @@ public class CompletedLoginProcess extends LoginProcess {
      */
     @Override
     public String getSuccessURL() {
+        RedirectUrlValidator<String> urlValidator =
+            new RedirectUrlValidator<String>(ValidGotoUrlExtractor.getInstance());
         try {
-            return ssoToken.getProperty(ISAuthConstants.SUCCESS_URL);
+            return urlValidator.getRedirectUrl(getOrgDN(),
+                    urlValidator.getAndDecodeParameter(getLoginConfiguration().getHttpRequest(), urlValidator.GOTO),
+                    ssoToken.getProperty(ISAuthConstants.SUCCESS_URL));
         } catch (SSOException e) {
             e.printStackTrace();
         }

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
- * Portions copyright 2019-2022 OSSTech Corporation
+ * Portions copyright 2019-2026 OSSTech Corporation
  */
 
 define([
@@ -99,30 +99,37 @@ define([
     obj.setSuccessURL = function (tokenId, successUrl) {
         const promise = $.Deferred();
         const paramString = URIUtils.getCurrentCompositeQueryString();
-        const goto = query.parseParameters(paramString).goto;
-        if (goto) {
+        let paramgoto = query.parseParameters(paramString).goto;
+        const successvalidategotoURL = function (data) {
             let context = "";
-            AuthNService.validateGotoUrl(goto).then((data) => {
-                if (data.successURL.indexOf("/") === 0 &&
-                    data.successURL.indexOf(`/${Constants.context}`) !== 0) {
-                    context = `/${Constants.context}`;
-                }
-                gotoUrl.set(encodeURIComponent(context + data.successURL));
-                promise.resolve();
-            }, () => {
-                promise.reject();
-            });
-        } else {
-            if (successUrl !== Constants.CONSOLE_PATH) {
-                if (!Configuration.globalData.auth.urlParams) {
-                    Configuration.globalData.auth.urlParams = {};
-                }
-
-                if (!gotoUrl.exists()) {
-                    gotoUrl.set(successUrl);
-                }
+            let redirectUrl = "";
+            if (data.successURL.indexOf("/") === 0 &&
+                data.successURL.indexOf(`/${Constants.context}`) !== 0) {
+                context = `/${Constants.context}`;
+            }
+            redirectUrl = context + data.successURL;
+            if (redirectUrl !== Constants.CONSOLE_PATH) {
+                gotoUrl.set(encodeURIComponent(redirectUrl));
+            } else {
+                delete Configuration.globalData.auth.urlParams.goto;
             }
             promise.resolve();
+        };
+        const failvalidategotoURL = function () {
+            promise.reject();
+        };
+
+        if (successUrl) {
+            AuthNService.validateGotoUrl(successUrl).then(function (data) {
+                successvalidategotoURL(data);
+            }, failvalidategotoURL);
+        } else if (paramgoto) {
+            paramgoto = decodeURIComponent(paramgoto);
+            AuthNService.validateGotoUrl(paramgoto).then(function (data) {
+                successvalidategotoURL(data);
+            }, failvalidategotoURL);
+        } else {
+            failvalidategotoURL();
         }
         return promise;
     };

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2011-2016 ForgeRock AS.
- * Portions copyright 2019 Open Source Solution Technology Corporation
+ * Portions copyright 2019-2026 OSSTech Corporation
  */
 define([
     "jquery",
@@ -249,7 +249,6 @@ define([
         }
     };
     obj.validateGotoUrl = function (goto) {
-        goto = decodeURIComponent(goto);
         return obj.serviceCall({
             type: "POST",
             headers: { "Accept-API-Version": "protocol=1.0,resource=2.0" },


### PR DESCRIPTION
## Solution

`POST_PROCESS_LOGIN_SUCCESS_URL` take precedence over the goto parameter.

## Testing

* On successful authentication
    * Only the `goto` parameter -> Redirect to the URL specified by `goto`
    * Only `POST_PROCESS_LOGIN_SUCCESS_URL` -> Redirect to the URL specified by `POST_PROCESS_LOGIN_SUCCESS_URL`
    * Both `goto` parameter & `POST_PROCESS_LOGIN_SUCCESS_URL` -> Redirect to the URL specified by `POST_PROCESS_LOGIN_SUCCESS_URL`
* When already authenticated and accessing the login URL
    * With `goto` parameter -> Redirect to the URL specified by `goto`
    * Without `goto` parameter -> Redirect to the user profile screen