### PR TITLE
Issue #415 When 500 error occurs in the authentication REST API, "User name/password combination is invalid." is displayed

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/services/AuthNService.js
@@ -197,6 +197,9 @@ define([
                     message = $.t("config.messages.CommonMessages.unknown");
                 }
                 Messages.addMessage({ message, type: Messages.TYPE_DANGER });
+                // The reason used here will not be translated into a common message and hence not displayed.
+                // This is so that only the message above is displayed.
+                return $.Deferred().reject(currentStage, reasonThatWillNotBeDisplayed).promise();
             } else { // we have a 401 unauthorized response
                 errorBody = $.parseJSON(jqXHR.responseText);
                 // if the error body has an authId property, then we may be


### PR DESCRIPTION
## Solution

Fix error handling when 500 error occurs.

## Testing

The issue does not reproduce by following the steps described in #415.
