### PR TITLE
Issue #425 ClassCastException occurs when Desktop SSO authentication fails

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/callbackhandlers/RestAuthHttpCallbackHandler.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/callbackhandlers/RestAuthHttpCallbackHandler.java
@@ -11,9 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2013-2015 ForgeRock AS.
+ * Copyright 2013-2016 ForgeRock AS.
  */
-
 package org.forgerock.openam.core.rest.authn.callbackhandlers;
 
 import com.sun.identity.authentication.spi.HttpCallback;
@@ -86,7 +85,7 @@ public class RestAuthHttpCallbackHandler extends AbstractRestAuthCallbackHandler
     public HttpCallback handle(HttpServletRequest request, HttpServletResponse response,
             JsonValue postBody, HttpCallback originalCallback) {
         if (isJsonAttributePresent(postBody, "reason") && postBody.get("reason").asString().equals(HTTP_AUTH_FAILED)) {
-            request.setAttribute(HTTP_AUTH_FAILED, true);
+            request.setAttribute(HTTP_AUTH_FAILED, Boolean.TRUE.toString());
         }
         return originalCallback;
     }

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/authn/callbackhandlers/RestAuthHttpCallbackHandlerTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/authn/callbackhandlers/RestAuthHttpCallbackHandlerTest.java
@@ -161,7 +161,7 @@ public class RestAuthHttpCallbackHandlerTest {
 
         //Then
         Assert.assertEquals(originalHttpCallback, httpCallback);
-        verify(request).setAttribute("http-auth-failed", true);
+        verify(request).setAttribute("http-auth-failed", "true");
     }
 
     @Test
@@ -179,7 +179,7 @@ public class RestAuthHttpCallbackHandlerTest {
 
         //Then
         Assert.assertEquals(originalHttpCallback, httpCallback);
-        verify(request, never()).setAttribute("http-auth-failed", true);
+        verify(request, never()).setAttribute("http-auth-failed", "true");
     }
 
     @Test (expectedExceptions = RestAuthException.class)


### PR DESCRIPTION
## Solution

cherry picked from commit 68e12b243.

## Testing

Even if Desktop SSO authentication fails, `ClassCastException` does not occur.